### PR TITLE
fix: 修复Redis连接配置以支持ACL格式的用户名和密码

### DIFF
--- a/backend/app/config/setting.py
+++ b/backend/app/config/setting.py
@@ -292,7 +292,7 @@ class Settings(BaseSettings):
         if settings.REDIS_PASSWORD is None:
             return f"redis://{settings.REDIS_HOST}:{settings.REDIS_PORT}/{settings.REDIS_DB_NAME}"
         else:
-            return f"redis://:{settings.REDIS_PASSWORD}@{settings.REDIS_HOST}:{settings.REDIS_PORT}/{settings.REDIS_DB_NAME}"
+            return f"redis://{settings.REDIS_PASSWORD}@{settings.REDIS_HOST}:{settings.REDIS_PORT}/{settings.REDIS_DB_NAME}"
     
     @property
     def FASTAPI_CONFIG(self) -> Dict[str, Union[str, bool, None]]:

--- a/backend/app/core/ap_scheduler.py
+++ b/backend/app/core/ap_scheduler.py
@@ -32,16 +32,23 @@ from app.api.v1.cruds.system.job_crud import JobCRUD
 from app.api.v1.models.system.job_model import JobModel
 
 # job 存储
+# 处理Redis 5.0+ ACL格式的用户名:密码
+redis_config = {
+    'host': settings.REDIS_HOST,
+    'port': settings.REDIS_PORT,
+    'db': settings.REDIS_DB_NAME,
+}
+
+if settings.REDIS_PASSWORD and ':' in settings.REDIS_PASSWORD:
+    username, password = settings.REDIS_PASSWORD.split(':', 1)
+    redis_config['username'] = username
+    redis_config['password'] = password
+else:
+    redis_config['password'] = settings.REDIS_PASSWORD
+
 job_stores = {
     'default': MemoryJobStore(),
-    'redis': RedisJobStore(
-        **dict(
-            password=settings.REDIS_PASSWORD,
-            host=settings.REDIS_HOST,
-            port=settings.REDIS_PORT,
-            db=settings.REDIS_DB_NAME,
-        )
-    ),
+    'redis': RedisJobStore(**redis_config),
 }
 # 配置执行器
 executors = {'default': AsyncIOExecutor(), 'processpool': ProcessPoolExecutor(5)}


### PR DESCRIPTION
兼容ACL用户的REDIS链接
后端配置  REDIS_PASSWORD = "user:password"
