### PR TITLE
refactor(依赖): 移除CustomException中的冗余status_code参数

### DIFF
--- a/backend/app/core/dependencies.py
+++ b/backend/app/core/dependencies.py
@@ -140,11 +140,11 @@ class AuthPermission:
             # 严格模式:要求所有权限都满足
             if not all(perm in user_permissions for perm in self.permissions):
                 logger.error(f"用户 {auth.user.name} 缺少所需的权限: {self.permissions}")
-                raise CustomException(msg="无权限操作", status_code=403)
+                raise CustomException(msg="无权限操作")
         else:
             # 非严格模式:满足任一权限即可
             if not any(perm in user_permissions for perm in self.permissions):
                 logger.error(f"用户 {auth.user.name} 缺少任何所需的权限: {self.permissions}")
-                raise CustomException(msg="无权限操作", status_code=403)
+                raise CustomException(msg="无权限操作")
 
         return auth


### PR DESCRIPTION
在AuthPermission类中，CustomException的status_code参数始终为403，因此移除该参数以简化代码