### PR TITLE
fix(redis配置): 将日志文件路径改为标准输出

### DIFF
--- a/devops/redis/conf/redis.conf
+++ b/devops/redis/conf/redis.conf
@@ -299,7 +299,7 @@ loglevel notice
 # Specify the log file name. Also the empty string can be used to force
 # Redis to log on the standard output. Note that if you use standard
 # output for logging but daemonize, logs will be sent to /dev/null
-logfile "/etc/redis.log"
+logfile ""
 
 # To enable logging to the system logger, just set 'syslog-enabled' to yes,
 # and optionally update the other syslog parameters to suit your needs.


### PR DESCRIPTION
修改redis.conf配置文件，将logfile从"/etc/redis.log"改为空字符串，使Redis日志输出到标准输出。这样在容器化部署时更方便查看日志。