### PR TITLE
refactor(start.sh): 合并容器管理和前端构建步骤到更新流程

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -38,27 +38,18 @@ check_dependencies() {
     log "✅ 所有依赖检查通过"
 }
 
-# 停止并删除容器
-stop_and_remove_containers() {
-    log "==========🗑️ 第三步：终止容器...=========="
-    cd "${WORK_DIR}" || { log "❌ 无法进入工作目录：${WORK_DIR}"; exit 1; }
-    if [ -d "${PROJECT_NAME}/" ]; then
-        cd "${PROJECT_NAME}" || { log "❌ 无法进入项目目录：${PROJECT_NAME}"; exit 1; }
-        [ -f "docker-compose.yaml" ] || { log "❌ docker-compose.yaml 文件未找到"; exit 1; }
-        docker compose down
-        log "✅ 容器已停止并删除"
-    else
-        log "⚠️ 项目目录不存在，跳过容器终止"
-    fi
-}
-
 # 更新代码
 update_code() {
-    log "==========🔍 第四步：检查项目...=========="
+    log "==========🔍 第三步：检查项目...=========="
     cd "${WORK_DIR}" || { log "❌ 无法进入工作目录：${WORK_DIR}"; exit 1; }
     if [ -d "${PROJECT_NAME}/" ]; then
         log "🔄 项目已存在，开始更新代码"
         cd "${PROJECT_NAME}" || { log "❌ 无法进入项目目录：${PROJECT_NAME}"; exit 1; }
+        
+        [ -f "docker-compose.yaml" ] || { log "❌ docker-compose.yaml 文件未找到"; exit 1; }
+        docker compose down
+        log "✅ 容器已停止并删除"
+        
         git pull --force || { log "❌ 拉取更新失败"; exit 1; }
         git log -1 || { log "❌ 获取提交信息失败"; exit 1; }
         log "✅ 代码更新成功"
@@ -70,32 +61,23 @@ update_code() {
     fi
 }
 
-# 构建前端
-build_frontend() {
-    log "==========🔍 第五步：检查前端...=========="
-    # 如果是首次克隆项目，或者检测到前端代码变更，则构建前端
-    if [ ! -d "frontend/dist" ] || [ "$(git diff --name-only HEAD~1 HEAD -- frontend/)" ]; then
-        log "🚀 检测到前端代码变更或首次克隆，开始构建前端..."
-        cd frontend || { log "❌ 无法进入前端目录"; exit 1; }
-        npm install || { log "❌ 前端依赖安装失败"; exit 1; }
-        npm run build || { log "❌ 前端工程打包失败"; exit 1; }
-        log "✅ 前端工程打包成功"
-        cd .. || { log "❌ 无法返回项目根目录"; exit 1; }
-    else
-        log "⚠️ 未检测到前端代码变更且非首次克隆，跳过前端构建"
-    fi
-}
-
 # 构建镜像
 build_image() {
-    log "==========🚀 第六步：构建镜像...==========🗑️ "
+    log "==========🚀 第四步：构建镜像...==========🗑️ "
+
+    cd frontend || { log "❌ 无法进入前端目录"; exit 1; }
+    npm install || { log "❌ 前端依赖安装失败"; exit 1; }
+    npm run build || { log "❌ 前端工程打包失败"; exit 1; }
+    log "✅ 前端工程打包成功"
+    cd .. || { log "❌ 无法返回项目根目录"; exit 1; }
+
     docker compose build || { log "❌ 镜像构建失败"; exit 1; }
     log "✅  Docker镜像构建成功"
 }
 
 # 启动容器
 start_containers() {
-    log "==========🚀 第七步：启动容器...==========🗑️ "
+    log "==========🚀 第五步：启动容器...==========🗑️ "
     docker compose up -d --force-recreate || { log "❌ 容器启动失败"; exit 1; }
     log "✅  容器启动成功"
 }
@@ -103,8 +85,8 @@ start_containers() {
 
 # 清理旧镜像
 cleanup_old_images() {
-    log "==========🗑️ 第八步：清理24小时前的旧镜像...==========🗑️ "
-    docker image prune -f --filter "until=24h"
+    log "==========🗑️ 第六步：清理72小时前的旧镜像...==========🗑️ "
+    docker image prune -f --filter "until=72h"
     log "✅ 旧镜像清理完成"
 }
 
@@ -113,9 +95,7 @@ main() {
     log "==========🚀 开始部署流程=========="
     check_permissions
     check_dependencies
-    stop_and_remove_containers
     update_code
-    build_frontend
     build_image
     start_containers
     cleanup_old_images


### PR DESCRIPTION
将停止容器和前端构建步骤合并到更新代码流程中，简化部署步骤
清理旧镜像的时间从24小时调整为72小时