### PR TITLE
fix(nginx): 更新fastapp静态文件路径和API路由前缀

### DIFF
--- a/devops/nginx/nginx.conf
+++ b/devops/nginx/nginx.conf
@@ -54,11 +54,10 @@ http {
             root /usr/share/nginx/html;    #nginx容器规定位置;
             index index.html index.htm;
             try_files $uri $uri/ /fastapp/index.html; #解决页面刷新404问题
-            
         }
 
         # 后端代理
-        location  /gateway/api/v1 {
+        location  /api/v1 {
             proxy_set_header Host $host;
             proxy_set_header  X-Real-IP        $remote_addr;
             proxy_set_header  X-Forwarded-For  $proxy_add_x_forwarded_for;

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -67,7 +67,7 @@ services:
     volumes:
       - ./devops/nginx/nginx.conf:/etc/nginx/nginx.conf
       - ./frontend/dist:/usr/share/nginx/html/frontend
-      - ./fastapp/dist:/usr/share/nginx/html/fastapp
+      - ./fastapp/dist/build/h5:/usr/share/nginx/html/fastapp
       - ./fastdocs/dist:/usr/share/nginx/html/fastdocs
     depends_on:
       - backend


### PR DESCRIPTION
修正nginx配置中fastapp静态文件的路径指向正确的构建目录
将后端API路由前缀从/gateway/api/v1简化为/api/v1