### PR TITLE
docs: 统一表格列宽样式为div格式

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -270,7 +270,7 @@ fastapi_vue3_admin/devops/devops/nginx/nginx.conf
 
 ### 移动端
 
-| Module { width="80" }| Details | Module { width="80" }| Details | Module { width="80" }| Details |
+| Module <div style="width:60px"/> | Details | Module <div style="width:60px"/> | Details | Module <div style="width:60px"/> | Details |
 |----------|------|----------|------|----------|------|
 | Login    | ![Mobile Login](./fastdocs/src/public/app_login.png) | Home      | ![Mobile Home](./fastdocs/src/public/app_home.png) | Profile      | ![Mobile Profile](./fastdocs/src/public/app_mine.png) |
 | Personal  | ![Mobile Personal Info](./fastdocs/src/public/app_profile.png) | Settings   | ![Mobile Settings](./fastdocs/src/public/app_setting.png) | Workbench      | ![Mobile Workbench](./fastdocs/src/public/app_work.png) |

--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ fastapi_vue3_amdin/devops/devops/nginx/nginx.conf
 
 ### 移动端
 
-| 模块 { width="80" }| 详情 | 模块 { width="80" }| 详情 | 模块 { width="80" }| 详情 |
+| 模块 <div style="width:60px"/> | 详情 | 模块 <div style="width:60px"/> | 详情 | 模块 <div style="width:60px"/> | 详情 |
 |----------|------|----------|------|----------|------|
 | 登录    | ![移动端登录](./fastdocs/src/public/app_login.png) | 首页      | ![移动端首页](./fastdocs/src/public/app_home.png) | 我的      | ![移动端个人中心](./fastdocs/src/public/app_mine.png) |
 | 个人  | ![移动端个人信息](./fastdocs/src/public/app_profile.png) | 设置   | ![移动端设置](./fastdocs/src/public/app_setting.png) | 工作台      | ![移动端工作台](./fastdocs/src/public/app_work.png) |

--- a/fastdocs/src/guide_start.md
+++ b/fastdocs/src/guide_start.md
@@ -142,7 +142,7 @@ fastapi_vue3_admin/devops/devops/nginx/nginx.conf
 
 ### web 端
 
-| 模块名{ width="100" } | 截图 |
+| 模块名 <div style="width:60px"/>  | 截图 |
 |----------|------|
 | 登录      | ![登录](/login.png) |
 | 仪表盘    | ![仪表盘](/dashboard.png) |
@@ -166,7 +166,7 @@ fastapi_vue3_admin/devops/devops/nginx/nginx.conf
 
 ### 移动端
 
-| 模块 { width="80" }| 详情 | 模块 { width="80" }| 详情 | 模块 { width="80" }| 详情 |
+| 模块 <div style="width:60px"/> | 详情 | 模块 <div style="width:60px"/> | 详情 | 模块 <div style="width:60px"/> | 详情 |
 |----------|------|----------|------|----------|------|
 | 登录    | ![移动端登录](/app_login.png) | 首页      | ![移动端首页](/app_home.png) | 我的      | ![移动端个人中心](/app_mine.png) |
 | 个人  | ![移动端个人信息](/app_profile.png) | 设置   | ![移动端设置](/app_setting.png) | 工作台      | ![移动端工作台](/app_work.png) |


### PR DESCRIPTION
将README和指南文档中的表格列宽样式从{width="xx"}统一修改为<div style="width:xxpx"/>格式，提高样式兼容性