### PR TITLE
feat(中间件): 添加演示环境IP白名单功能

### DIFF
--- a/backend/app/config/setting.py
+++ b/backend/app/config/setting.py
@@ -179,6 +179,10 @@ class Settings(BaseSettings):
     DEMO_BLACK_LIST_PATH: List[str] = [  # 演示黑名单
         "/auth/login"
     ]
+    DEMO_IP_WHITE_LIST: List[str] = [  # 演示白名单IP
+        "192.168.18.7",
+        "192.168.1.3"
+    ]
 
     # ================================================= #
     # ***************** 静态文件配置 ***************** #

--- a/backend/app/core/middlewares.py
+++ b/backend/app/core/middlewares.py
@@ -77,7 +77,8 @@ class DemoEnvMiddleware(BaseHTTPMiddleware):
     async def dispatch(
             self, request: Request, call_next: RequestResponseEndpoint
     ) -> Response:
-        if settings.DEMO_ENABLE and request.method != "GET":
+        client_ip = request.client.host
+        if settings.DEMO_ENABLE and request.method != "GET" and client_ip not in settings.DEMO_IP_WHITE_LIST:
             path = request.scope.get("path")
             if path in settings.DEMO_BLACK_LIST_PATH:
                 return ErrorResponse(msg="演示环境，禁止操作",)


### PR DESCRIPTION
在演示环境中间件中添加IP白名单检查，只有白名单中的IP才能执行非GET请求