### PR TITLE
build: 更新 requirements.txt 中的依赖项

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,7 +2,7 @@ alembic==1.15.1         # 数据库迁移
 APScheduler==3.11.0     # 定时任务
 # celery==5.4.0         # 任务队列(移除，使用APScheduler)
 fastapi==0.115.2
-fastapi-mcp==0.4.0
+Jinja2==3.1.6
 typer==0.9.0
 click==8.1.7
 uvicorn==0.30.6         # uvicorn web 框架


### PR DESCRIPTION
将 fastapi-mcp 替换为 Jinja2 以支持模板渲染功能