### PR TITLE
fix(api): 修正示例模块分页参数和消息提示

### DIFF
--- a/backend/app/api/v1/module_example/demo/controller.py
+++ b/backend/app/api/v1/module_example/demo/controller.py
@@ -41,7 +41,7 @@ async def get_obj_list_controller(
     result_dict_list = await DemoService.get_demo_list_service(auth=auth, search=search, order_by=page.order_by)
     result_dict = await PaginationService.paginate(data_list= result_dict_list, page_no= page.page_no, page_size = page.page_size)
     logger.info(f"查询示例列表成功")
-    return SuccessResponse(data=result_dict, msg="查询公告列表成功")
+    return SuccessResponse(data=result_dict, msg="查询示例列表成功")
 
 @DemoRouter.post("/create", summary="创建示例", description="创建示例")
 async def create_obj_controller(

--- a/backend/app/api/v1/module_example/demo/crud.py
+++ b/backend/app/api/v1/module_example/demo/crud.py
@@ -14,7 +14,7 @@ class DemoCRUD(CRUDBase[DemoModel, DemoCreateSchema, DemoUpdateSchema]):
     def __init__(self, auth: AuthSchema) -> None:
         """初始化CRUD"""
         self.auth = auth
-        super().__init__(model=DemoModel(), auth=auth)
+        super().__init__(model=DemoModel, auth=auth)
 
     async def get_by_id_crud(self, id: int) -> Optional[DemoModel]:
         """详情"""

--- a/frontend/src/views/gencode/backcode/index.vue
+++ b/frontend/src/views/gencode/backcode/index.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="app-container">
-    <el-form :model="queryParams" ref="queryRef" :inline="true" v-show="showSearch">
+    <el-form v-show="showSearch" ref="queryRef" :model="queryParams" :inline="true" >
       <el-form-item label="表名称" prop="tableName">
         <el-input
           v-model="queryParams.tableName"
@@ -91,7 +91,7 @@
       <el-table-column type="selection" align="center" width="55"></el-table-column>
       <el-table-column label="序号" type="index" width="50" align="center">
         <template #default="scope">
-          <span>{{(queryParams.pageNum - 1) * queryParams.pageSize + scope.$index + 1}}</span>
+          <span>{{(queryParams.page_no - 1) * queryParams.page_size + scope.$index + 1}}</span>
         </template>
       </el-table-column>
       <el-table-column
@@ -137,8 +137,8 @@
     <pagination
       v-show="total>0"
       :total="total"
-      v-model:page="queryParams.pageNum"
-      v-model:limit="queryParams.pageSize"
+      v-model:page="queryParams.page_no"
+      v-model:limit="queryParams.page_size"
       @pagination="getList"
     />
     <!-- 预览界面 -->
@@ -187,8 +187,8 @@ const uniqueId = ref("");
 
 const data = reactive({
   queryParams: {
-    pageNum: 1,
-    pageSize: 10,
+    page_no: 1,
+    page_size: 10,
     tableName: undefined,
     tableComment: undefined
   },
@@ -206,7 +206,7 @@ onActivated(() => {
   const time = route.query.t;
   if (time != null && time != uniqueId.value) {
     uniqueId.value = time;
-    queryParams.value.pageNum = Number(route.query.pageNum);
+    queryParams.value.page_no = Number(route.query.page_no);
     dateRange.value = [];
     proxy.resetForm("queryForm");
     getList();
@@ -225,7 +225,7 @@ function getList() {
 
 /** 搜索按钮操作 */
 function handleQuery() {
-  queryParams.value.pageNum = 1;
+  queryParams.value.page_no = 1;
   getList();
 }
 
@@ -305,7 +305,7 @@ function handleSelectionChange(selection) {
 /** 修改按钮操作 */
 function handleEditTable(row) {
   const tableId = row.tableId || ids.value[0];
-  router.push({ path: "/tool/gen-edit/index/" + tableId, query: { pageNum: queryParams.value.pageNum } });
+  router.push({ path: "/tool/gen-edit/index/" + tableId, query: { page_no: queryParams.value.page_no } });
 }
 
 /** 删除按钮操作 */


### PR DESCRIPTION
- 修改DemoCRUD中父类初始化调用，使用模型类而非实例
- 统一API中返回的消息提示为“查询示例列表成功”
- 前端gencode页面调整分页参数字段从pageNum和pageSize为page_no和page_size
- 更新分页计算中序号的计算逻辑以匹配新参数名
- 修正路由跳转时分页参数名称，确保正确传递page_no值
- 调整表单元素属性顺序优化代码可读性