### PR TITLE
refactor: 统一语言包键名并移除创建人列

### DIFF
--- a/frontend/src/lang/package/en.ts
+++ b/frontend/src/lang/package/en.ts
@@ -1,6 +1,6 @@
 export default {
   // Common section
-  module_common: {
+  common: {
     confirm: "Confirm",
     cancel: "Cancel",
     reset: "Reset",

--- a/frontend/src/lang/package/zh-cn.ts
+++ b/frontend/src/lang/package/zh-cn.ts
@@ -1,6 +1,6 @@
 export default {
   // 公共部分
-  module_common: {
+  common: {
     confirm: "确定",
     cancel: "取消",
     reset: "重置",

--- a/frontend/src/views/module_system/tenant/index.vue
+++ b/frontend/src/views/module_system/tenant/index.vue
@@ -164,11 +164,11 @@
         <el-table-column v-if="tableColumns.find((col) => col.prop === 'description')?.show" label="描述" prop="description" min-width="140" />
         <el-table-column v-if="tableColumns.find((col) => col.prop === 'created_at')?.show" label="创建时间" prop="created_at" min-width="180" />
         <el-table-column v-if="tableColumns.find((col) => col.prop === 'updated_at')?.show" label="更新时间" prop="updated_at" min-width="180" />
-        <el-table-column v-if="tableColumns.find((col) => col.prop === 'creator')?.show" label="创建人" prop="creator" min-width="120">
+        <!-- <el-table-column v-if="tableColumns.find((col) => col.prop === 'creator')?.show" label="创建人" prop="creator" min-width="120">
           <template #default="scope">
             <el-tag>{{ scope.row.creator?.name }}</el-tag>
           </template>
-        </el-table-column>
+        </el-table-column> -->
         <el-table-column v-if="tableColumns.find(col => col.prop === 'operation')?.show" fixed="right" label="操作" align="center" min-width="180">
           <template #default="scope">
             <el-button v-hasPerm="['module_generator:tenant:detail']" type="info" size="small" link icon="document" @click="handleOpenDialog('detail', scope.row.id)">详情</el-button>


### PR DESCRIPTION
将语言包中的 module_common 统一重命名为 common 以提高一致性
移除租户列表中的创建人列以简化界面