### PR TITLE
fix: 修复前端表格高度语法错误并完善菜单ID处理

### DIFF
--- a/backend/app/utils/jinja2_template_util.py
+++ b/backend/app/utils/jinja2_template_util.py
@@ -121,6 +121,7 @@ class Jinja2TemplateUtil:
             'db_type': settings.DATABASE_TYPE,
             'column_not_add_show': GenConstant.COLUMNNAME_NOT_ADD_SHOW,
             'column_not_edit_show': GenConstant.COLUMNNAME_NOT_EDIT_SHOW,
+            'parent_menu_id': int(gen_table.parent_menu_id) if gen_table.parent_menu_id is not None else int(cls.DEFAULT_PARENT_MENU_ID),
         }
 
         return context

--- a/backend/templates/sql/sql.sql.j2
+++ b/backend/templates/sql/sql.sql.j2
@@ -28,7 +28,7 @@ VALUES (
   '{{ function_name }}',
   NULL,
   {{ b_false }},
-  {{ parent_menu_id if parent_menu_id else 'NULL' }},
+  {{ parent_menu_id }},
   '{{ function_name }}菜单',
   now(),
   now()
@@ -76,7 +76,7 @@ WITH parent AS (
     '{{ function_name }}',
     NULL,
     {{ b_false }},
-    {{ parent_menu_id if parent_menu_id else 'NULL' }},
+    {{ parent_menu_id }},
     '{{ function_name }}菜单',
     now(),
     now()
@@ -102,7 +102,7 @@ SELECT '{{ function_name }}下载导入模板', 3, 8, {{ b_true }}, '{{ permissi
 {% else %}
 -- 未识别的数据库类型，默认按 MySQL 处理
 INSERT INTO `system_menu` (name, type, {{ order_col }}, status, permission, icon, route_name, route_path, component_path, redirect, hidden, keep_alive, always_show, title, params, affix, parent_id, description, created_at, updated_at)
-VALUES ('{{ function_name }}', 2, 1, {{ b_true }}, '{{ permission_prefix }}:query', NULL, '{{ business_name|snake_to_camel }}', '/{{ module_name }}/{{ business_name }}', '{{ module_name }}/{{ business_name }}/index', NULL, {{ b_false }}, {{ b_true }}, {{ b_false }}, '{{ function_name }}', NULL, {{ b_false }}, {{ parent_menu_id if parent_menu_id else 'NULL' }}, '{{ function_name }}菜单', now(), now());
+VALUES ('{{ function_name }}', 2, 1, {{ b_true }}, '{{ permission_prefix }}:query', NULL, '{{ business_name|snake_to_camel }}', '/{{ module_name }}/{{ business_name }}', '{{ module_name }}/{{ business_name }}/index', NULL, {{ b_false }}, {{ b_true }}, {{ b_false }}, '{{ function_name }}', NULL, {{ b_false }}, {{ parent_menu_id }}, '{{ function_name }}菜单', now(), now());
 SELECT @parentId := LAST_INSERT_ID();
 INSERT INTO `system_menu` (name, type, {{ order_col }}, status, permission, icon, route_name, route_path, component_path, redirect, hidden, keep_alive, always_show, title, params, affix, parent_id, description, created_at, updated_at)
 VALUES ('{{ function_name }}查询', 3, 1, {{ b_true }}, '{{ permission_prefix }}:query',   NULL, NULL, NULL, NULL, NULL, {{ b_false }}, {{ b_true }}, {{ b_false }}, '{{ function_name }}查询',   NULL, {{ b_false }}, @parentId, '', now(), now());

--- a/frontend/src/views/module_system/log/index.vue
+++ b/frontend/src/views/module_system/log/index.vue
@@ -135,7 +135,7 @@
         :data="pageTableData"
         highlight-current-row
         class="data-table__content"
-        ::height="450"
+        :height="450"
         border
         stripe
         @selection-change="handleSelectionChange"


### PR DESCRIPTION
修复前端表格组件中错误的双冒号语法，改为单冒号绑定高度属性
在Jinja2模板工具中添加parent_menu_id的默认值处理
统一SQL模板中parent_menu_id的处理逻辑，移除NULL判断