### PR TITLE
docs: 更新README中群组二维码的图片链接分支

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -475,7 +475,7 @@ Thanks to the contributions and support of the following open-source projects:
 
 | Group QR Code | WeChat Pay QR Code |
 | --- | --- |
-| ![Group QR Code](https://gitee.com/fastapiadmin/FastDocs/raw/main/docs/public/group.jpg) | ![WeChat Pay QR Code](https://gitee.com/fastapiadmin/FastDocs/raw/main/docs/public/wechatPay.jpg) |
+| ![Group QR Code](https://gitee.com/fastapiadmin/FastDocs/raw/master/docs/public/group.jpg) | ![WeChat Pay QR Code](https://gitee.com/fastapiadmin/FastDocs/raw/main/docs/public/wechatPay.jpg) |
 
 ## ❤️ Support the Project
 

--- a/README.md
+++ b/README.md
@@ -458,7 +458,7 @@ A：使用 `./deploy.sh` 脚本一键部署到生产环境。
 
 | 群组二维码 | 微信支付二维码 |
 | --- | --- |
-| ![群组二维码](https://gitee.com/fastapiadmin/FastDocs/raw/main/docs/public/group.jpg) | ![微信支付二维码](https://gitee.com/fastapiadmin/FastDocs/raw/main/docs/public/wechatPay.jpg) |
+| ![群组二维码](https://gitee.com/fastapiadmin/FastDocs/raw/master/docs/public/group.jpg) | ![微信支付二维码](https://gitee.com/fastapiadmin/FastDocs/raw/main/docs/public/wechatPay.jpg) |
 
 ## ❤️ 支持项目
 


### PR DESCRIPTION
将群组二维码图片链接从main分支改为master分支以保持一致性