### PR TITLE
docs: 统一微信支付二维码图片路径

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -475,7 +475,7 @@ Thanks to the contributions and support of the following open-source projects:
 
 | Group QR Code | WeChat Pay QR Code |
 | --- | --- |
-| ![Group QR Code](https://gitee.com/fastapiadmin/FastDocs/raw/master/docs/public/group.jpg) | ![WeChat Pay QR Code](https://gitee.com/fastapiadmin/FastDocs/raw/main/docs/public/wechatPay.jpg) |
+| ![Group QR Code](https://gitee.com/fastapiadmin/FastDocs/raw/master/docs/public/group.jpg) | ![WeChat Pay QR Code](https://gitee.com/fastapiadmin/FastDocs/raw/master/docs/public/wechatPay.jpg) |
 
 ## ❤️ Support the Project
 

--- a/README.md
+++ b/README.md
@@ -458,7 +458,7 @@ A：使用 `./deploy.sh` 脚本一键部署到生产环境。
 
 | 群组二维码 | 微信支付二维码 |
 | --- | --- |
-| ![群组二维码](https://gitee.com/fastapiadmin/FastDocs/raw/master/docs/public/group.jpg) | ![微信支付二维码](https://gitee.com/fastapiadmin/FastDocs/raw/main/docs/public/wechatPay.jpg) |
+| ![群组二维码](https://gitee.com/fastapiadmin/FastDocs/raw/master/docs/public/group.jpg) | ![微信支付二维码](https://gitee.com/fastapiadmin/FastDocs/raw/master/docs/public/wechatPay.jpg) |
 
 ## ❤️ 支持项目
 


### PR DESCRIPTION
将微信支付二维码图片路径从raw/main改为raw/master以保持一致性