### PR TITLE
refactor(ip解析): 移除LOGIN_RESOLVE_IP_LOCATION配置，改用DEBUG控制IP解析

### DIFF
--- a/backend/app/config/setting.py
+++ b/backend/app/config/setting.py
@@ -120,9 +120,6 @@ class Settings(BaseSettings):
     CAPTCHA_FONT_SIZE: int = 32  # 字体大小
     CAPTCHA_FONT_PATH: str = "static/assets/font/Arial.ttf"  # 字体路径
 
-    # 是否请求外网解析 IP 归属地（登录发 token、操作日志写 login_location 共用；关闭可明显加快登录）
-    LOGIN_RESOLVE_IP_LOCATION: bool = False
-
     # ================================================= #
     # ******************* 外部 HTTP（httpx）******************* #
     # ================================================= #

--- a/backend/app/utils/ip_local_util.py
+++ b/backend/app/utils/ip_local_util.py
@@ -46,7 +46,7 @@ class IpLocalUtil:
         """
         登录与操作日志写入 ``login_location`` 时的统一解析入口。
 
-        与 ``settings.LOGIN_RESOLVE_IP_LOCATION`` 联动：关闭时不请求外网，仅返回占位描述，
+        与 ``settings.DEBUG`` 联动：如果 ``DEBUG`` 为 ``False`` 时，关闭解析，不请求外网，仅返回占位描述，
         避免登录 POST 在 ``OperationLogRoute`` 收尾阶段因外网查询变慢。
 
         参数:
@@ -57,7 +57,7 @@ class IpLocalUtil:
         """
         if not ip:
             return None
-        if not settings.LOGIN_RESOLVE_IP_LOCATION:
+        if settings.DEBUG:
             return (
                 "内网IP"
                 if cls.is_private_ip(ip)


### PR DESCRIPTION
不再使用单独的LOGIN_RESOLVE_IP_LOCATION配置项控制IP归属地解析，改为直接依赖DEBUG模式设置。当DEBUG为False时关闭外网IP解析功能，减少登录时的网络请求延迟。