### PR TITLE
refactor(CURD): 统一工具栏按钮类型和权限命名

### DIFF
--- a/backend/app/plugin/module_generator/gencode/templates/vue/index.vue.j2
+++ b/backend/app/plugin/module_generator/gencode/templates/vue/index.vue.j2
@@ -473,7 +473,7 @@ const contentConfig = reactive<IContentConfig<{{ class_name }}PageQuery>>({
   initialFetch: false,
   cols: contentCols as IContentConfig["cols"],
   toolbar: [],
-  defaultToolbar: ["import", "exports", "search", "refresh", "filter"],
+  defaultToolbar: ["import", "export", "patch", "search", "refresh", "filter"],
   pagination: {
     pageSize: 10,
     pageSizes: [10, 20, 30, 50],

--- a/frontend/plop-templates/curd-list-page.vue.hbs
+++ b/frontend/plop-templates/curd-list-page.vue.hbs
@@ -69,7 +69,7 @@ const searchConfig = reactive<ISearchConfig>({
 const contentConfig = reactive<IContentConfig>({
   permPrefix: "{{permPrefix}}",
   toolbar: [],
-  defaultToolbar: ["refresh", "filter"],
+  defaultToolbar: ["import", "export", "patch", "search", "refresh", "filter"],
   cols: [],
   /** TODO: 接入列表 API，返回 { total, list } 供 PageContent 解析 */
   indexAction: async () => ({ total: 0, list: [] }),

--- a/frontend/src/components/CURD/CrudToolbarRight.vue
+++ b/frontend/src/components/CURD/CrudToolbarRight.vue
@@ -44,9 +44,8 @@ defineProps<{
 
 const TOOLTIPS: Record<string, string> = {
   import: "导入",
-  imports: "批量导入",
   export: "导出",
-  exports: "导出",
+  filter: "筛选",
   search: "搜索显示/隐藏",
   refresh: "刷新",
 };

--- a/frontend/src/components/CURD/ImportModal.vue
+++ b/frontend/src/components/CURD/ImportModal.vue
@@ -41,6 +41,7 @@
                   </el-text>
                   <el-link
                     v-if="props.showTemplateDownload"
+                    v-hasPerm="[`${props.contentConfig.permPrefix}:download`]"
                     class="mx-1"
                     type="primary"
                     icon="download"

--- a/frontend/src/components/CURD/PageContent.vue
+++ b/frontend/src/components/CURD/PageContent.vue
@@ -377,18 +377,16 @@ const emit = defineEmits<{
 // 表格工具栏按钮配置
 const config = computed(() => props.contentConfig);
 const buttonConfig = reactive<Record<string, IObject>>({
-  add: { text: "新增", attrs: { icon: "plus", type: "success" }, perm: "add" },
+  add: { text: "新增", attrs: { icon: "plus", type: "success" }, perm: "create" },
   delete: { text: "删除", attrs: { icon: "delete", type: "danger" }, perm: "delete" },
-  /** 右侧圆形工具条：与业务页手写工具栏（如 user、demo）语义色一致 */
+  patch: { text: "批量修改", attrs: { icon: "edit", type: "warning" }, perm: "patch" },
   import: { text: "导入", attrs: { icon: "upload", type: "info" }, perm: "import" },
   export: { text: "导出", attrs: { icon: "download", type: "warning" }, perm: "export" },
   refresh: { text: "刷新", attrs: { icon: "refresh", type: "success" }, perm: "*:*:*" },
   filter: { text: "筛选列", attrs: { icon: "operation", type: "danger" }, perm: "*:*:*" },
-  search: { text: "搜索", attrs: { icon: "search", type: "info" }, perm: "search" },
-  imports: { text: "批量导入", attrs: { icon: "upload", type: "success" }, perm: "imports" },
-  exports: { text: "批量导出", attrs: { icon: "download", type: "warning" }, perm: "exports" },
-  view: { text: "查看", attrs: { icon: "view", type: "primary" }, perm: "view" },
-  edit: { text: "编辑", attrs: { icon: "edit", type: "primary" }, perm: "edit" },
+  search: { text: "搜索", attrs: { icon: "search", type: "info" }, perm: "query" },
+  view: { text: "详情", attrs: { icon: "view", type: "primary" }, perm: "detail" },
+  edit: { text: "编辑", attrs: { icon: "edit", type: "primary" }, perm: "update" },
 });
 
 // 主键
@@ -807,7 +805,7 @@ function handleToolbar(name: string) {
     case "refresh":
       handleRefresh();
       break;
-    case "exports":
+    case "export":
       handleOpenExportsModal();
       break;
     case "imports":
@@ -822,11 +820,11 @@ function handleToolbar(name: string) {
     case "delete":
       handleDelete();
       break;
+    case "patch":
+      emit("toolbarClick", name);
+      break;
     case "import":
       handleOpenImportModal(true);
-      break;
-    case "export":
-      emit("exportClick");
       break;
     default:
       emit("toolbarClick", name);

--- a/frontend/src/components/CURD/types.ts
+++ b/frontend/src/components/CURD/types.ts
@@ -43,8 +43,8 @@ export type IComponentType = DateComponent | InputComponent | OtherComponent;
 /**
  * 工具按钮类型定义
  */
-type ToolbarLeft = "add" | "delete" | "import" | "export";
-type ToolbarRight = "refresh" | "filter" | "import" | "imports" | "exports" | "search";
+type ToolbarLeft = "add" | "delete" | "patch";
+type ToolbarRight = "refresh" | "filter" | "import" | "export" | "search";
 type ToolbarTable = "edit" | "view" | "delete";
 
 /**
@@ -204,7 +204,7 @@ export interface IContentConfig<T = any> {
   pk?: string;
   /** 表格工具栏(默认:add,delete,export,也可自定义) */
   toolbar?: Array<ToolbarLeft | IToolsButton>;
-  /** 表格工具栏右侧图标(默认:refresh,filter,imports,exports,search) */
+  /** 表格工具栏右侧图标(默认:refresh,filter,import,export,patch,search) */
   defaultToolbar?: Array<ToolbarRight | IToolsButton>;
   /** 使用 #table 插槽自定义表格/树表时，为 true 则隐藏「列筛选」按钮（避免与自定义列不同步） */
   hideColumnFilter?: boolean;

--- a/frontend/src/views/module_ai/memory/index.vue
+++ b/frontend/src/views/module_ai/memory/index.vue
@@ -381,8 +381,8 @@ const contentConfig = reactive<IContentConfig>({
   permPrefix: "module_ai:chat",
   cols: [],
   hideColumnFilter: true,
-  toolbar: ["add", "delete"],
-  defaultToolbar: ["search", "refresh"],
+  toolbar: ["add", "delete", "patch"],
+  defaultToolbar: ["import", "export", "search", "refresh", "filter"],
   pagination: {
     pageSize: 10,
     pageSizes: [10, 20, 30, 50],

--- a/frontend/src/views/module_example/demo/index.vue
+++ b/frontend/src/views/module_example/demo/index.vue
@@ -570,7 +570,7 @@ const contentConfig = reactive<IContentConfig<DemoPageQuery>>({
   initialFetch: false,
   cols: contentCols as IContentConfig["cols"],
   toolbar: [],
-  defaultToolbar: ["import", "exports", "search", "refresh", "filter"],
+  defaultToolbar: ["import", "export", "search", "refresh", "filter"],
   pagination: {
     pageSize: 10,
     pageSizes: [10, 20, 30, 50],

--- a/frontend/src/views/module_example/demo01/index.vue
+++ b/frontend/src/views/module_example/demo01/index.vue
@@ -402,7 +402,7 @@ const contentConfig = reactive<IContentConfig<Demo01PageQuery>>({
   initialFetch: false,
   cols: contentCols as IContentConfig["cols"],
   toolbar: [],
-  defaultToolbar: ["import", "exports", "search", "refresh", "filter"],
+  defaultToolbar: ["import", "export", "search", "refresh", "filter"],
   pagination: {
     pageSize: 10,
     pageSizes: [10, 20, 30, 50],

--- a/frontend/src/views/module_system/menu/index.vue
+++ b/frontend/src/views/module_system/menu/index.vue
@@ -807,7 +807,7 @@ const contentConfig = reactive<IContentConfig<MenuPageQuery>>({
   cols: contentCols as IContentConfig["cols"],
   hideColumnFilter: true,
   toolbar: [],
-  defaultToolbar: ["refresh"],
+  defaultToolbar: ["refresh", "filter"],
   pagination: false,
   indexAction: async (params) => {
     const res = await MenuAPI.listMenu(params as MenuPageQuery);

--- a/frontend/src/views/module_system/param/index.vue
+++ b/frontend/src/views/module_system/param/index.vue
@@ -377,7 +377,7 @@ const contentConfig = reactive<IContentConfig<ConfigPageQuery>>({
   cols: contentCols as IContentConfig["cols"],
   hideColumnFilter: false,
   toolbar: [],
-  defaultToolbar: [{ name: "refresh", perm: "refresh" }, "filter"],
+  defaultToolbar: ["search", "refresh", "filter"],
   pagination: {
     pageSize: 10,
     pageSizes: [10, 20, 30, 50],

--- a/frontend/src/views/module_system/position/index.vue
+++ b/frontend/src/views/module_system/position/index.vue
@@ -388,7 +388,7 @@ const contentConfig = reactive<IContentConfig<PositionPageQuery>>({
   cols: contentCols as IContentConfig["cols"],
   hideColumnFilter: false,
   toolbar: [],
-  defaultToolbar: [{ name: "refresh", perm: "refresh" }, "filter"],
+  defaultToolbar: ["search", "refresh", "filter"],
   pagination: {
     pageSize: 10,
     pageSizes: [10, 20, 30, 50],

--- a/frontend/src/views/module_system/role/index.vue
+++ b/frontend/src/views/module_system/role/index.vue
@@ -467,7 +467,7 @@ const contentConfig = reactive<IContentConfig<TablePageQuery>>({
   cols: contentCols as IContentConfig["cols"],
   hideColumnFilter: false,
   toolbar: [],
-  defaultToolbar: [{ name: "refresh", perm: "query" }, "filter"],
+  defaultToolbar: ["search", "refresh", "filter"],
   pagination: {
     pageSize: 10,
     pageSizes: [10, 20, 30, 50],

--- a/frontend/src/views/module_system/tenant/index.vue
+++ b/frontend/src/views/module_system/tenant/index.vue
@@ -375,7 +375,7 @@ const contentConfig = reactive<IContentConfig<TenantPageQuery>>({
   cols: contentCols as IContentConfig["cols"],
   hideColumnFilter: false,
   toolbar: [],
-  defaultToolbar: [{ name: "refresh", perm: "refresh" }, "filter"],
+  defaultToolbar: ["import", "export", "search", "refresh", "filter"],
   pagination: {
     pageSize: 10,
     pageSizes: [10, 20, 30, 50],

--- a/frontend/src/views/module_system/user/index.vue
+++ b/frontend/src/views/module_system/user/index.vue
@@ -511,7 +511,7 @@ const contentConfig = reactive<IContentConfig<UserPageQuery>>({
   hideColumnFilter: true,
   initialFetch: false,
   toolbar: [],
-  defaultToolbar: [{ name: "refresh", perm: "query" }],
+  defaultToolbar: ["import", "export", "search", "refresh", "filter"],
   pagination: {
     pageSize: 10,
     pageSizes: [10, 20, 30, 50],

--- a/frontend/src/views/module_task/cronjob/node/index.vue
+++ b/frontend/src/views/module_task/cronjob/node/index.vue
@@ -414,7 +414,7 @@ const contentConfig = reactive<IContentConfig<NodePageQuery>>({
   cols: [],
   hideColumnFilter: true,
   toolbar: ["add", "delete"],
-  defaultToolbar: ["refresh"],
+  defaultToolbar: ["search", "refresh", "filter"],
   pagination: {
     pageSize: 10,
     pageSizes: [10, 20, 30, 50],


### PR DESCRIPTION
标准化工具栏按钮类型定义，移除重复项并统一权限命名
更新多个视图的默认工具栏配置以保持一致
添加批量修改按钮并调整相关权限名称