### PR TITLE
feat(menu): 支持一级菜单直接渲染页面组件

### DIFF
--- a/frontend/src/components/Breadcrumb/index.vue
+++ b/frontend/src/components/Breadcrumb/index.vue
@@ -1,6 +1,6 @@
 <template>
   <el-breadcrumb class="flex-y-center">
-    <el-breadcrumb-item v-for="(item, index) in breadcrumbs" :key="item.path">
+    <el-breadcrumb-item v-for="(item, index) in breadcrumbs" :key="index">
       <span
         v-if="item.redirect === 'noredirect' || index === breadcrumbs.length - 1"
         class="color-gray-400"
@@ -35,9 +35,14 @@ function getBreadcrumb() {
   if (!isDashboard(first)) {
     matched = [{ path: "/home", meta: { title: "dashboard" } } as any].concat(matched);
   }
-  breadcrumbs.value = matched.filter((item) => {
+  matched = matched.filter((item) => {
     return item.meta && item.meta.title && item.meta.breadcrumb !== false;
   });
+  // 去重：连续相同 path 只保留最后一个（如 Layout 包装层与实际页面 path 相同）
+  breadcrumbs.value = matched.filter(
+    (item, index) => index === matched.length - 1 || item.path !== matched[index + 1].path,
+  );
+
 }
 
 function isDashboard(route: RouteLocationMatched) {

--- a/frontend/src/store/modules/permission.store.ts
+++ b/frontend/src/store/modules/permission.store.ts
@@ -45,7 +45,10 @@ export interface RouteVO {
  * 后端常把「模块目录」与「其下功能菜单」写成同一绝对 route_path（如均为 /module_xxx/demo02）。
  * Vue Router 嵌套子路由应使用空 path 挂到父 path 下，否则重复绝对路径会导致匹配异常。
  */
-function normalizeMenuNestedPaths(items: MenuTable[], parentAbsolutePath?: string): MenuTable[] {
+function normalizeMenuNestedPaths(
+  items: MenuTable[],
+  parentAbsolutePath?: string,
+): MenuTable[] {
   return items.map((node) => {
     const raw = (node.route_path ?? "").trim();
     let routePath: string | null | undefined = node.route_path;
@@ -139,7 +142,9 @@ export const usePermissionStore = defineStore("permission", () => {
    */
   const resetRouter = () => {
     // 创建常量路由名称集合，用于O(1)时间复杂度的查找
-    const constantRouteNames = new Set(constantRoutes.map((route) => route.name).filter(Boolean));
+    const constantRouteNames = new Set(
+      constantRoutes.map((route) => route.name).filter(Boolean),
+    );
 
     // 从 router 实例中移除动态路由
     routes.value.forEach((route) => {
@@ -168,7 +173,10 @@ export const usePermissionStore = defineStore("permission", () => {
  * 转换后端路由数据为Vue Router配置
  * 处理组件路径映射和Layout层级嵌套
  */
-const transformRoutes = (routes: RouteVO[], isTopLevel: boolean = true): RouteRecordRaw[] => {
+const transformRoutes = (
+  routes: RouteVO[],
+  isTopLevel: boolean = true,
+): RouteRecordRaw[] => {
   return routes.map((route) => {
     // 创建路由对象，保留所有路由属性
     const normalizedRoute = { ...route } as RouteRecordRaw;
@@ -185,8 +193,6 @@ const transformRoutes = (routes: RouteVO[], isTopLevel: boolean = true): RouteRe
     // 3. 叶子路由使用实际组件
     // 4. 递归处理子路由，实现无限层级菜单
     if (normalizedRoute.children && normalizedRoute.children.length > 0) {
-      // normalizedRoute.children = transformRoutes(route.children);
-
       // 非叶子路由
       if (isTopLevel) {
         // 顶级路由（一级目录），使用Layout组件
@@ -197,8 +203,25 @@ const transformRoutes = (routes: RouteVO[], isTopLevel: boolean = true): RouteRe
       }
       // 递归处理子路由，标记为非顶级路由
       normalizedRoute.children = transformRoutes(route.children, false);
+    } else if (isTopLevel && normalizedRoute.component) {
+      // 顶级叶子路由：自动包装 Layout，使其在侧边栏显示为一级菜单
+      const childComponent = normalizedRoute.component
+        ? modules[`../../views/${normalizedRoute.component}.vue`] ||
+          modules["../../views/error/404.vue"]
+        : modules["../../views/error/404.vue"];
+      const originalName = normalizedRoute.name;
+      normalizedRoute.name = `${String(originalName)}Parent`;
+      normalizedRoute.component = Layout;
+      normalizedRoute.children = [
+        {
+          path: "",
+          name: originalName,
+          meta: normalizedRoute.meta,
+          component: childComponent,
+        } as RouteRecordRaw,
+      ];
     } else {
-      // 叶子路由，使用实际组件
+      // 非顶级叶子路由，使用实际组件
       normalizedRoute.component = normalizedRoute.component
         ? modules[`../../views/${normalizedRoute.component}.vue`] ||
           modules["../../views/error/404.vue"]

--- a/frontend/src/views/module_system/menu/index.vue
+++ b/frontend/src/views/module_system/menu/index.vue
@@ -842,7 +842,18 @@ const rules = reactive({
     { required: true, message: "请输入菜单名称", trigger: "blur" },
     { min: 2, max: 50, message: "长度 2 到 50 个字符", trigger: "blur" },
   ],
-  parent_id: [{ required: true, message: "请选择父级菜单", trigger: "blur" }],
+  parent_id: [
+    {
+      validator: (_rule: any, value: any, callback: any) => {
+        if (formData.type === MenuTypeEnum.BUTTON && !value) {
+          callback(new Error("请选择父级菜单"));
+        } else {
+          callback();
+        }
+      },
+      trigger: "blur",
+    },
+  ],
   type: [{ required: true, message: "请选择菜单类型", trigger: "blur" }],
   order: [{ required: true, message: "请输入排序", trigger: "blur" }],
   permission: [{ required: true, message: "请输入权限标识", trigger: "blur" }],
@@ -943,12 +954,19 @@ async function handleOpenDialog(
   createParentLocked.value = false;
   if (id) {
     const response = await MenuAPI.detailMenu(id);
+    const data = response.data.data as Record<string, any>;
+    // 后端可能返回 null，字符串字段需回退为 "" 以满足 el-input/el-select 的 modelValue 类型要求
+    for (const key of Object.keys(data)) {
+      if (data[key] === null) {
+        data[key] = "";
+      }
+    }
     if (type === "detail") {
       dialogVisible.title = "菜单详情";
-      Object.assign(detailFormData.value, response.data.data);
+      Object.assign(detailFormData.value, data);
     } else if (type === "update") {
       dialogVisible.title = "修改菜单";
-      Object.assign(formData, response.data.data);
+      Object.assign(formData, data);
     }
   } else {
     dialogVisible.title = "新增菜单";


### PR DESCRIPTION
- transformRoutes 新增顶级叶子路由处理，自动包装 Layout 组件使其在侧边栏显示为一级菜单
- 菜单管理 parent_id 校验改为动态规则，仅按钮类型必填，菜单/外链支持无父级
- 编辑菜单时后端返回 null 字段统一回退为空字符串，修复 el-input modelValue 类型警告

解决问题：
- 菜单可以不必绑定目录，这样可以直接创建有页面的一级菜单，如"首页"这种
- 其他代码为了解决这部分改动引起的其他问题