### PR TITLE
fix(docker): 更新健康检查路径并优化构建与日志

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -449,9 +449,9 @@ show_containers_logs() {
     log "📊 当前容器状态：" "INFO"
     docker compose ps --format "table {{.Service}}\t{{.Name}}\t{{.Status}}\t{{.Ports}}"
 
-    log "📋 服务日志：" "INFO"
+    log "📋 服务日志（最近 50 行，实时跟踪请用 docker compose logs -f [服务名]）：" "INFO"
     echo "----------------------------------------"
-    docker compose logs
+    docker compose logs --tail=50 --no-log-prefix 2>/dev/null || docker compose logs --tail=50
     echo "----------------------------------------"
 }
 

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -45,15 +45,12 @@ RUN groupadd -r fastapiadmin && \
 
 WORKDIR /home
 
-# 从构建阶段复制依赖
-COPY --from=builder /home/deps /home/deps
+# 从构建阶段复制依赖（直接指定所有者，避免后续 chown）
+COPY --from=builder --chown=fastapiadmin:fastapiadmin /home/deps /home/deps
 ENV PYTHONPATH=/home/deps:$PYTHONPATH
 
-# 复制应用代码
-COPY ./backend/ .
-
-# 更改文件所有权
-RUN chown -R fastapiadmin:fastapiadmin /home
+# 复制应用代码（一步到位设置所有者，省去 chmod -R 耗时）
+COPY --chown=fastapiadmin:fastapiadmin ./backend/ .
 
 # 切换到非 root 用户
 USER fastapiadmin
@@ -62,6 +59,6 @@ EXPOSE 8001
 
 # 容器健康检查
 HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
-    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8001/api/v1/health')" || exit 1
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8001/common/health')" || exit 1
 
 CMD ["python", "main.py", "run", "--env=prod"]

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -121,7 +121,7 @@ services:
       test:
         [
           "CMD-SHELL",
-          "python -c 'import urllib.request; urllib.request.urlopen(\"http://localhost:8001/api/v1/health\")' || exit 1",
+          "python -c 'import urllib.request; urllib.request.urlopen(\"http://localhost:8001/common/health\")' || exit 1",
         ]
       interval: 15s
       timeout: 10s

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -98,8 +98,9 @@ http {
 
     # ==================== HTTPS Server ====================
     server {
-        listen 443 ssl http2;
-        listen [::]:443 ssl http2;
+        listen 443 ssl;
+        listen [::]:443 ssl;
+        http2 on;
         server_name service.fastapiadmin.com;
 
         # ==================== SSL 配置 ====================
@@ -139,6 +140,12 @@ http {
             try_files $uri $uri/ /app/index.html;
             expires 1h;
             add_header Cache-Control "public, no-transform";
+        }
+
+        location /api/v1/common/health {
+            access_log off;
+            return 200 "OK";
+            add_header Content-Type text/plain;
         }
 
         # ==================== 后端 API 代理 ====================


### PR DESCRIPTION
- 修正健康检查端点从 /api/v1/health 至 /common/health
- Nginx 新增 /api/v1/common/health 直接返回 200 以绕过日志
- Dockerfile 使用 COPY --chown 替代 RUN chown -R 以提升构建速度
- deploy.sh 限制日志输出最近 50 行并去除前缀
- Nginx SSL 配置更新为 http2 on 指令以兼容新版本