### PR TITLE
chore: rename docker compose example file to default config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,8 +66,6 @@ frontend/web/.env.dev
 frontend/web/.env.prod
 frontend/web/.env.test
 
-docker/docker-compose.yaml
-
 frontend/node_modules
 frontend/dist
 frontend/src/types/auto-imports.d.ts

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -24,6 +24,8 @@ services:
     volumes:
       - mysql_data:/var/lib/mysql
       - /etc/localtime:/etc/localtime:ro
+      # 首次启动时自动执行 init SQL 脚本
+      - ./mysql/init:/docker-entrypoint-initdb.d:ro
     networks:
       - app_network
     healthcheck:
@@ -57,13 +59,11 @@ services:
       - "${REDIS_PORT:-6379}:6379"
     volumes:
       - redis_data:/data
+      # 挂载自定义 redis.conf（若存在则覆盖默认配置）
+      - ./redis/conf/redis.conf:/usr/local/etc/redis/redis.conf:ro
     command: >
-      redis-server
+      redis-server /usr/local/etc/redis/redis.conf
       --requirepass ${REDIS_PASSWORD:?错误: 请设置 REDIS_PASSWORD 环境变量}
-      --appendonly yes
-      --appendfsync everysec
-      --auto-aof-rewrite-percentage 100
-      --auto-aof-rewrite-min-size 64mb
     networks:
       - app_network
     healthcheck:
@@ -91,23 +91,36 @@ services:
     build:
       context: ../
       dockerfile: ./docker/backend/Dockerfile
-    image: backend:3.0.0
+      args:
+        DEPLOY_ENV: "${DEPLOY_ENV:-prod}"
+    image: "backend:${BACKEND_IMAGE_TAG:-3.0.0}"
     restart: unless-stopped
     platform: linux/amd64
     environment:
       TZ: "Asia/Shanghai"
+      # 运行环境，对应 backend/env/.env.{dev,prod}
+      ENVIRONMENT: "${DEPLOY_ENV:-prod}"
+      # MySQL 连接配置
       DATABASE_HOST: "mysql"
-      DATABASE_PASSWORD: "${MYSQL_PASSWORD}"
       DATABASE_PORT: "3306"
-      DATABASE_NAME: "${MYSQL_DATABASE:-fastapiadmin}"
       DATABASE_USER: "${MYSQL_USER:-fastapiadmin}"
+      DATABASE_PASSWORD: "${MYSQL_PASSWORD:?错误: 请设置 MYSQL_PASSWORD 环境变量}"
+      DATABASE_NAME: "${MYSQL_DATABASE:-fastapiadmin}"
+      # Redis 连接配置
       REDIS_HOST: "redis"
-      REDIS_PASSWORD: "${REDIS_PASSWORD}"
       REDIS_PORT: "6379"
+      REDIS_PASSWORD: "${REDIS_PASSWORD}"
+      REDIS_DB_NAME: "1"
+      REDIS_ENABLE: "true"
+      # 日志级别
+      LOGGER_LEVEL: "${LOGGER_LEVEL:-INFO}"
     ports:
       - "${BACKEND_PORT:-8001}:8001"
-    # 挂载宿主机代码到容器（热更新，生产环境保留以便读取 .env.prod 等配置文件）
     volumes:
+      # ── 注意 ──────────────────────────────────
+      # 以下挂载将宿主机代码覆盖容器内代码，实现热更新。
+      # 生产环境建议注释掉该行，使用镜像内自带的代码。
+      # ─────────────────────────────────────────
       - ../backend:/home
     depends_on:
       mysql:
@@ -153,9 +166,10 @@ services:
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
       - ./nginx/web:/usr/share/nginx/html/web:ro
+      - ./nginx/ssl:/etc/nginx/ssl:ro
+      # 按需启用（取消注释）：
       # - ./nginx/app:/usr/share/nginx/html/app:ro
       # - ./nginx/docs:/usr/share/nginx/html/docs:ro
-      - ./nginx/ssl:/etc/nginx/ssl:ro
     depends_on:
       backend:
         condition: service_started


### PR DESCRIPTION
1. 移除.gitignore中对docker-compose.yaml的忽略规则
2. 删除原docker-compose-example.yaml文件
3. 将示例配置重命名为正式的docker-compose.yaml主配置文件
4. 更新了配置文件内容，新增了init SQL脚本挂载、redis自定义配置挂载等优化项