### PR TITLE
feat(console): add database type display in startup status

### DIFF
--- a/backend/app/init_app.py
+++ b/backend/app/init_app.py
@@ -38,6 +38,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[Any, Any]:
         host=settings.SERVER_HOST,
         port=settings.SERVER_PORT,
         reload=settings.DEBUG,
+        database_type=settings.DATABASE_TYPE,
         database_ready=True,
         redis_ready=True,
         scheduler_ready=SchedulerUtil.is_running(),

--- a/backend/app/utils/console.py
+++ b/backend/app/utils/console.py
@@ -17,6 +17,7 @@ def console_start(
     port: int,
     reload: bool,
     *,
+    database_type: str | None = None,
     database_ready: bool | None = None,
     redis_ready: bool | None = None,
     scheduler_ready: bool | None = None,
@@ -26,6 +27,7 @@ def console_start(
     参数:
     - host (str): 监听主机。
     - port (int): 监听端口。
+    - database_type (str | None): 数据库类型。
     - reload (bool): 是否开启热重载。
     - database_ready (bool | None): 数据库是否就绪。
     - redis_ready (bool | None): Redis 是否就绪。
@@ -66,7 +68,7 @@ def console_start(
     status_grid.add_column(justify="right")
     status_grid.add_column()
     status_grid.add_row(
-        "MySQL", _status_text(database_ready),
+        database_type,  _status_text(database_ready),
         sep,
         "Redis", _status_text(redis_ready),
         sep,


### PR DESCRIPTION
1. 新增database_type参数传递到控制台启动函数
2. 在启动状态面板中显示实际数据库类型替代硬编码的MySQL
3. 更新函数文档注释说明新增的参数