### PR TITLE
fix(hooks): useTable 去重 key 计入 apiFn 身份，修复同页多表串数据

### DIFF
--- a/frontend/web/src/__tests__/useTable.dedupe.spec.ts
+++ b/frontend/web/src/__tests__/useTable.dedupe.spec.ts
@@ -1,0 +1,203 @@
+/**
+ * useTable 跨实例 in-flight 请求去重的隔离性测试。
+ *
+ * 回归背景：`globalListNetworkInflight` 是模块级、全应用共享的去重 Map，
+ * 但 dedupeKey 曾只由请求参数序列化而成、不含接口身份。于是两个不同接口
+ * 只要参数恰好相同（最典型：都只有 page_no/page_size 默认值），后发起的
+ * 表格就会复用前一个接口进行中的请求，把别人的响应提交成自己的数据 ——
+ * 更糟的是自己的接口根本不会被调用。
+ *
+ * 同页多表（如 views/module_system/log 的操作日志 / 登录日志两个 tab）必然踩中。
+ */
+import { mount } from "@vue/test-utils";
+import { defineComponent, h } from "vue";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+// useTable 从 @utils 取工具函数，这里只桩掉它实际用到的那几个，
+// 避免把整个 utils 桶（axios / element-plus 等）拉进 jsdom。
+vi.mock("@utils", () => ({
+  CacheInvalidationStrategy: {
+    CLEAR_ALL: "clear_all",
+    CLEAR_CURRENT: "clear_current",
+    CLEAR_PAGINATION: "clear_pagination",
+    KEEP_ALL: "keep_all",
+  },
+  TableCache: class {},
+  createErrorHandler: () => (_error: unknown, message: string) => ({
+    code: "TEST_ERROR",
+    message,
+  }),
+  createSmartDebounce: (fn: (...args: unknown[]) => Promise<unknown>) =>
+    Object.assign((...args: unknown[]) => fn(...args), { cancel: vi.fn() }),
+  defaultResponseAdapter: vi.fn(),
+  extractTableData: <T>(response: { records: T[] }) => response.records,
+  tableConfig: {
+    paginationKey: { current: "page_no", size: "page_size" },
+  },
+  updatePaginationFromResponse: (pagination: { total: number }, response: { total: number }) => {
+    pagination.total = response.total;
+  },
+}));
+
+let useTable: typeof import("@/hooks/core/useTable").useTable;
+
+beforeAll(async () => {
+  vi.stubGlobal("__APP_INFO__", {
+    pkg: {
+      name: "fastapiadmin",
+      version: "test",
+      engines: { node: ">=20.19.0" },
+      dependencies: {},
+      devDependencies: {},
+    },
+    buildTimestamp: 0,
+  });
+  ({ useTable } = await import("@/hooks/core/useTable"));
+});
+
+afterAll(() => {
+  vi.unstubAllGlobals();
+});
+
+interface TestParams {
+  page_no: number;
+  page_size: number;
+}
+
+interface TestRow {
+  id: number;
+  source: string;
+}
+
+type TestResponse = ApiResponse<PageResult<TestRow>>;
+
+/** 只取断言需要的两个成员，避免依赖 useTable 完整返回类型 */
+interface TableHandle {
+  data: { value: TestRow[] };
+  fetchData: () => Promise<unknown>;
+}
+
+/** 手动控制 resolve 时机，制造「两个请求同时在飞」的去重窗口 */
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+function createResponse(row: TestRow): TestResponse {
+  return {
+    code: 200,
+    data: { items: [row], total: 1, page_no: 1, page_size: 10, has_next: false },
+    msg: "success",
+    status_code: 200,
+    success: true,
+  };
+}
+
+function adaptResponse(response: TestResponse) {
+  return {
+    records: response.data.items,
+    total: response.data.total,
+    current: response.data.page_no,
+    size: response.data.page_size,
+    has_next: response.data.has_next,
+  };
+}
+
+/**
+ * 挂载一个组件，内部用两个 apiFn 各建一个表格，请求参数完全相同。
+ * 复刻 views/module_system/log 的结构：同一组件内两次 useTable。
+ */
+function mountTwoTables(
+  firstApi: (params: TestParams) => Promise<TestResponse>,
+  secondApi: (params: TestParams) => Promise<TestResponse>
+) {
+  let first!: TableHandle;
+  let second!: TableHandle;
+
+  const wrapper = mount(
+    defineComponent({
+      setup() {
+        const firstTable = useTable({
+          core: { apiFn: firstApi, apiParams: { page_no: 1, page_size: 10 }, immediate: false },
+          transform: { responseAdapter: adaptResponse },
+        });
+        const secondTable = useTable({
+          core: { apiFn: secondApi, apiParams: { page_no: 1, page_size: 10 }, immediate: false },
+          transform: { responseAdapter: adaptResponse },
+        });
+
+        first = { data: firstTable.data, fetchData: firstTable.fetchData };
+        second = { data: secondTable.data, fetchData: secondTable.fetchData };
+        return () => h("div");
+      },
+    })
+  );
+
+  return { wrapper, first, second };
+}
+
+describe("useTable 跨实例 in-flight 去重", () => {
+  it("参数相同但接口不同时，两个表格各自拿到自己接口的数据", async () => {
+    const firstRequest = createDeferred<TestResponse>();
+    const secondRequest = createDeferred<TestResponse>();
+    const firstApi = vi.fn((params: TestParams) => {
+      expect(params.page_size).toBe(10);
+      return firstRequest.promise;
+    });
+    const secondApi = vi.fn((params: TestParams) => {
+      expect(params.page_size).toBe(10);
+      return secondRequest.promise;
+    });
+
+    const { wrapper, first, second } = mountTwoTables(firstApi, secondApi);
+
+    try {
+      const firstRow: TestRow = { id: 1, source: "first-api" };
+      const secondRow: TestRow = { id: 2, source: "second-api" };
+
+      // 两个请求在同一 tick 发出、都还没 resolve —— 这正是去重窗口
+      const pending = Promise.all([first.fetchData(), second.fetchData()]);
+      firstRequest.resolve(createResponse(firstRow));
+      secondRequest.resolve(createResponse(secondRow));
+      await pending;
+
+      // 两个接口都必须真的被调用，不能有一个被「合并」掉
+      expect(firstApi).toHaveBeenCalledTimes(1);
+      expect(secondApi).toHaveBeenCalledTimes(1);
+
+      // 各自的数据不能串
+      expect(first.data.value).toEqual([firstRow]);
+      expect(second.data.value).toEqual([secondRow]);
+    } finally {
+      wrapper.unmount();
+    }
+  });
+
+  it("同一个接口 + 同参数时，仍然合并为一条请求", async () => {
+    const sharedRequest = createDeferred<TestResponse>();
+    const sharedApi = vi.fn((params: TestParams) => {
+      expect(params.page_size).toBe(10);
+      return sharedRequest.promise;
+    });
+
+    const { wrapper, first, second } = mountTwoTables(sharedApi, sharedApi);
+
+    try {
+      const sharedRow: TestRow = { id: 3, source: "shared-api" };
+
+      const pending = Promise.all([first.fetchData(), second.fetchData()]);
+      sharedRequest.resolve(createResponse(sharedRow));
+      await pending;
+
+      // 去重能力必须保留：只打一次网络
+      expect(sharedApi).toHaveBeenCalledTimes(1);
+      expect(first.data.value).toEqual([sharedRow]);
+      expect(second.data.value).toEqual([sharedRow]);
+    } finally {
+      wrapper.unmount();
+    }
+  });
+});

--- a/frontend/web/src/hooks/core/useTable.ts
+++ b/frontend/web/src/hooks/core/useTable.ts
@@ -6,7 +6,7 @@
  *
  * 去重：
  * - 同实例：`inFlightDedupePromise` + `inFlightDedupeKey`
- * - 跨实例（同参）：模块级 `globalListNetworkInflight`（布局短时多挂载时合并为一条 HTTP）
+ * - 跨实例（同接口 + 同参）：模块级 `globalListNetworkInflight`（布局短时多挂载时合并为一条 HTTP）
  *
  * KeepAlive：`onDeactivated` 会取消请求并置 `tableViewActive`，失活期间 `fetchData` 直接返回当前快照不发 HTTP。
  */
@@ -46,6 +46,27 @@ import type { ColumnOption } from "@/types/component";
 
 /** 跨组件实例：同一 dedupeKey 仅一条进行中的网络请求 */
 const globalListNetworkInflight = new Map<string, Promise<TableResponse<unknown>>>();
+
+/**
+ * apiFn 身份标记，用于计入 dedupeKey。
+ *
+ * dedupeKey 若只由请求参数拼成，两个不同接口只要参数恰好相同（最典型：都只有
+ * page_no/page_size 两个默认值），就会命中 `globalListNetworkInflight` 而互相
+ * 复用进行中的请求，导致后发起的表格拿到另一个接口的响应。同页多表必然踩中。
+ *
+ * 用 WeakMap 按函数引用分配稳定 id：同一接口仍然合并（去重能力不变），
+ * 不同接口永不互串。
+ */
+const apiFnIds = new WeakMap<object, number>();
+let apiFnIdSeq = 0;
+function apiFnId(fn: object): number {
+  let id = apiFnIds.get(fn);
+  if (id === undefined) {
+    id = ++apiFnIdSeq;
+    apiFnIds.set(fn, id);
+  }
+  return id;
+}
 
 // --- 类型推导（由 apiFn / 响应类型反推记录类型） ---
 type InferApiParams<T> = T extends (params: infer P) => any ? P : never;
@@ -223,7 +244,7 @@ function useTableImpl<TApiFn extends (params: any) => Promise<any>>(
   /** KeepAlive 失活时不再发请求（组件侧 cancelRequest 会 abort） */
   let tableViewActive = true;
 
-  /** 稳定序列化请求参，供 in-flight 去重用 */
+  /** 稳定序列化 apiFn 身份 + 请求参，供 in-flight 去重用（缺了 apiFn 会导致跨接口串数据） */
   function stableDedupeKeyFromParams(params: TParams): string {
     const normalize = (input: unknown): unknown => {
       if (input === null || typeof input !== "object") return input;
@@ -238,7 +259,7 @@ function useTableImpl<TApiFn extends (params: any) => Promise<any>>(
       }
       return out;
     };
-    return JSON.stringify(normalize(toRaw(params) as unknown));
+    return `${apiFnId(apiFn)}|${JSON.stringify(normalize(toRaw(params) as unknown))}`;
   }
 
   // 缓存清理定时器


### PR DESCRIPTION
globalListNetworkInflight 是模块级、全应用共享的 in-flight 去重 Map， 但 stableDedupeKeyFromParams 只序列化请求参数、不含接口身份。两个不同的
列表接口只要参数恰好相同（最典型：都只有 page_no/page_size 默认值），
后发起的表格就会命中前一个接口进行中的 Promise —— 自己的接口根本不会被
调用，却把别人的响应提交成了自己的数据。

项目自带的 views/module_system/log 就满足全部触发条件：同一组件内两次
useTable，apiParams 均为 { page_no: 1, page_size: 10 }。且这不是偶发竞态： immediate 默认为 true，两个 onMounted 在同一次 flush 连续执行，而 fetchData 从计算 dedupeKey 到写入全局 Map 之间没有 await，第一个同步注册完，第二个
必然查到。危害不止显示错乱 —— 表格行操作会拿另一张表的主键去调本表接口，
两表 id 空间重叠时可能静默误删。

改法：用 WeakMap 按函数引用给每个 apiFn 分配稳定 id 并拼进 dedupeKey。 语义严格收窄为「同接口 + 同参数才共享」，同接口的合并能力完全保留，
调用点零改动。

新增 src/__tests__/useTable.dedupe.spec.ts 覆盖两个方向：
- 不同接口 + 同参数：各自拿到自己的数据（修复前失败，secondApi 调用 0 次）
- 同接口 + 同参数：仍合并为一条请求（去重能力未退化）

验证：vitest 5 passed / vue-tsc --noEmit 通过 / eslint 与 prettier 均无问题