### PR TITLE
Update environment configuration file path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@
 git clone https://gitee.com/fastapiadmin/FastapiAdmin.git
 
 # 2. 配置环境
-cp backend/env/.env.dev.example backend/env/.env.dev
+cp backend/env/.env.example backend/env/.env.dev
 cp frontend/web/.env.development.example frontend/web/.env.development
 
 # 3. 启动后端（首次自动建表 + 初始化数据）

--- a/backend/README.md
+++ b/backend/README.md
@@ -72,7 +72,7 @@ module_*/
 
 ### 第一次在本机跑起来
 
-1. 复制 `env/.env.dev.example` → `env/.env.dev`，填写数据库、Redis 等（先在 DB 中建好空库）。
+1. 复制 `env/.env.example` → `env/.env.dev`，填写数据库、Redis 等（先在 DB 中建好空库）。
 2. 在 **`backend/` 目录下** 安装依赖：推荐 **`uv sync`**；或 `pip install -r requirements.txt`。
 3. **启动**：`uv run main.py run --env=dev`（或 `python main.py run --env=dev`）。**首次启动会自动初始化数据库表与基础数据**，一般**无需**先执行 `upgrade`。接口文档示例：`http://127.0.0.1:8001/docs`（端口见 `.env.dev` 中 `SERVER_PORT`）。
 


### PR DESCRIPTION
文档的配置环境这部分有误，现在仓库的配置模板是.env.example而不是.env.dev.example