### PR TITLE
fix(auth): stop unauthenticated password reset on forget-password

### DIFF
--- a/backend/app/api/v1/module_system/user/controller.py
+++ b/backend/app/api/v1/module_system/user/controller.py
@@ -71,15 +71,14 @@ async def reset_password_controller(
     return SuccessResponse(data=result_dict, msg="重置密码成功")
 
 
-@UserRouter.post("/password/forget", summary="忘记密码", response_model=ResponseSchema[UserOutSchema])
+@UserRouter.post("/password/forget", summary="忘记密码", response_model=ResponseSchema[None])
 async def forget_password_controller(
     db: Annotated[AsyncSession, Depends(db_getter)],
     data: Annotated[UserForgetPasswordSchema, Body(description="忘记密码参数")],
 ) -> JSONResponse:
     auth = AuthSchema()
-    user_forget_password_result = await UserService(auth, db).forget_password(data=data)
-    logger.info(f"{data.username} 重置密码成功")
-    return SuccessResponse(data=user_forget_password_result, msg="重置密码成功")
+    await UserService(auth, db).forget_password(data=data)
+    return SuccessResponse(msg="如果该账号存在，请联系管理员重置密码")
 
 
 @UserRouter.post("/register", summary="用户注册", response_model=ResponseSchema[UserOutSchema])

--- a/backend/app/api/v1/module_system/user/schema.py
+++ b/backend/app/api/v1/module_system/user/schema.py
@@ -67,10 +67,11 @@ class CurrentUserUpdateSchema(BaseModel):
 
 
 class UserForgetPasswordSchema(BaseModel):
-    """忘记密码"""
+    """忘记密码申请。仅接受用户名，不得携带新密码。"""
+
+    model_config = ConfigDict(extra="ignore")
 
     username: str = Field(..., min_length=3, max_length=32, description="用户名")
-    new_password: str = Field(..., min_length=6, max_length=128, description="新密码")
 
     @field_validator("username")
     @classmethod
@@ -83,16 +84,6 @@ class UserForgetPasswordSchema(BaseModel):
         if not re.match(r"^[A-Za-z][A-Za-z0-9_.-]{2,31}$", v):
             raise ValueError("账号需以字母开头，3-32 位，仅允许字母、数字、_ . -")
         return v
-
-    @field_validator("new_password")
-    @classmethod
-    def validate_new_password(cls, value: str):
-        """校验密码：6-128 位"""
-        if len(value) < 6:
-            raise ValueError("密码长度不能少于 6 位")
-        if len(value) > 128:
-            raise ValueError("密码长度不能超过 128 位")
-        return value
 
 
 class UserChangePasswordSchema(BaseModel):

--- a/backend/app/api/v1/module_system/user/service.py
+++ b/backend/app/api/v1/module_system/user/service.py
@@ -270,16 +270,16 @@ class UserService:
         await UserCRUD(self.auth, self.db).change_password(id=data.id, password_hash=new_password_hash)
         return await self.detail(id=data.id)
 
-    async def forget_password(self, data: UserForgetPasswordSchema) -> UserOutSchema:
-        user = await UserCRUD(self.auth, self.db).get_or_404(username=data.username)
-        if user.status == 1:
-            raise CustomException(msg="用户已停用")
-        if user.is_superuser:
-            raise CustomException(msg="超级管理员密码不能重置")
+    async def forget_password(self, data: UserForgetPasswordSchema) -> None:
+        """接受忘记密码申请，但不根据用户名直接改密。
 
-        new_password_hash = PwdUtil.hash_password(password=data.new_password)
-        await UserCRUD(self.auth, self.db).change_password(id=user.id, password_hash=new_password_hash)
-        return await self.detail(id=user.id)
+        未登录调用方不得设置新密码。管理员请使用 reset_password。
+        无论账号是否存在、是否停用、是否超管，均不返回可区分信息。
+        """
+        user = await UserCRUD(self.auth, self.db).get(username=data.username)
+        if user is not None and user.status == 0 and not user.is_superuser:
+            logger.info("password reset requested for username={}", data.username)
+        return None
 
     async def register(self, data: UserRegisterSchema) -> UserOutSchema:
         """用户注册"""

--- a/backend/tests/test_api_module_system.py
+++ b/backend/tests/test_api_module_system.py
@@ -116,7 +116,7 @@ class TestUser:
             test_client,
             "POST",
             "/system/user/password/forget",
-            json={"username": "admin", "new_password": "newpass123"},
+            json={"username": "admin"},
         )
 
     def test_user_password_reset(self, test_client: TestClient, auth_headers: dict) -> None:

--- a/frontend/app/src/api/module_system/user.ts
+++ b/frontend/app/src/api/module_system/user.ts
@@ -66,8 +66,7 @@ const UserAPI = {
    *
    * @param body 重置参数
    * @param body.username 用户名（字母开头，3-32 位）
-   * @param body.new_password 新密码（6-128 位）
-   * @returns 重置结果
+   * @returns 申请结果（不会直接改密）
    */
   forgetPassword(body: ForgetPasswordForm): Promise<void> {
     return http.Post(`${USER_BASE_URL}/password/forget`, body, { meta: { ignoreAuth: true } })
@@ -169,10 +168,9 @@ const UserAPI = {
 
 export default UserAPI
 
-/* 忘记密码表单（与后端 UserForgetPasswordSchema 一致，confirmPassword 为前端校验字段不提交） */
+/* 忘记密码申请（与后端 UserForgetPasswordSchema 一致，仅提交用户名） */
 export interface ForgetPasswordForm {
   username: string
-  new_password: string
 }
 
 /* 注册表单 */

--- a/frontend/app/src/locales/langs/en.json
+++ b/frontend/app/src/locales/langs/en.json
@@ -131,10 +131,11 @@
   "forget": {
     "navTitle": "Forgot Password",
     "title": "Forgot Password",
-    "submit": "Reset Password",
+    "submit": "Submit request",
     "submitting": "Submitting...",
     "toLogin": "Back to Login",
-    "success": "Password reset, please log in again"
+    "hint": "Passwords cannot be changed with only a username. Contact an administrator to reset it.",
+    "success": "If the account exists, please contact an administrator to reset the password"
   },
   "setting": {
     "navTitle": "Settings",

--- a/frontend/app/src/locales/langs/zh.json
+++ b/frontend/app/src/locales/langs/zh.json
@@ -131,10 +131,11 @@
   "forget": {
     "navTitle": "忘记密码",
     "title": "忘记密码",
-    "submit": "重置密码",
+    "submit": "提交申请",
     "submitting": "提交中...",
     "toLogin": "返回登录",
-    "success": "密码重置成功，请重新登录"
+    "hint": "系统不会根据用户名直接改密，请联系管理员在后台重置。",
+    "success": "如果该账号存在，请联系管理员重置密码"
   },
   "setting": {
     "navTitle": "设置",

--- a/frontend/app/src/pages/login/forget/index.vue
+++ b/frontend/app/src/pages/login/forget/index.vue
@@ -17,8 +17,6 @@ const submitting = ref(false)
 const forgetFormRef = ref()
 const forgetForm = reactive({
   username: '',
-  new_password: '',
-  confirmPassword: '',
 })
 
 /** 与后端 UserForgetPasswordSchema 一致：字母开头，3-32 位，仅允许字母、数字、_ . - */
@@ -29,20 +27,10 @@ const forgetSchema: FormSchema = {
   validate: (model) => {
     const errors: Array<{ path: Array<string | number>, message: string }> = []
     const username = String(model.username ?? '').trim()
-    const password = String(model.new_password ?? '')
-    const confirmPassword = String(model.confirmPassword ?? '')
     if (!username)
       errors.push({ path: ['username'], message: t('common.form.usernameRequired') })
     else if (!USERNAME_REG.test(username))
       errors.push({ path: ['username'], message: t('common.form.usernameFormat') })
-    if (!password)
-      errors.push({ path: ['new_password'], message: t('common.form.newPasswordRequired') })
-    else if (password.length < 6)
-      errors.push({ path: ['new_password'], message: t('common.form.passwordLength') })
-    if (!confirmPassword)
-      errors.push({ path: ['confirmPassword'], message: t('common.form.confirmNewRequired') })
-    else if (confirmPassword !== password)
-      errors.push({ path: ['confirmPassword'], message: t('common.form.mismatch') })
     return errors
   },
 }
@@ -58,7 +46,7 @@ async function handleSubmit() {
   const username = forgetForm.username.trim()
   submitting.value = true
   try {
-    await UserAPI.forgetPassword({ username, new_password: forgetForm.new_password })
+    await UserAPI.forgetPassword({ username })
     Storage.set(REMEMBER_ME_KEY, { username, remember: true })
     toast.success(t('forget.success'))
     uni.reLaunch({ url: '/pages/login/index' })
@@ -94,26 +82,7 @@ function goLogin() {
               prefix-icon="user"
             />
           </wd-form-item>
-          <wd-form-item prop="new_password" custom-style="margin-bottom: 14rpx; padding-left: 0; padding-right: 0;">
-            <wd-input
-              v-model="forgetForm.new_password"
-              :placeholder="t('common.form.newPasswordPlaceholder')"
-              show-password
-              clearable
-              :compact="false"
-              prefix-icon="lock"
-            />
-          </wd-form-item>
-          <wd-form-item prop="confirmPassword" custom-style="margin-bottom: 14rpx; padding-left: 0; padding-right: 0;">
-            <wd-input
-              v-model="forgetForm.confirmPassword"
-              :placeholder="t('common.form.confirmNewPlaceholder')"
-              show-password
-              clearable
-              :compact="false"
-              prefix-icon="lock"
-            />
-          </wd-form-item>
+          <wd-text class="forget-hint" :text="t('forget.hint')" />
         </wd-form>
         <wd-button type="primary" round block :loading="submitting" @click="handleSubmit">
           {{ submitting ? t('forget.submitting') : t('forget.submit') }}
@@ -218,6 +187,13 @@ function goLogin() {
   --wot-input-bg: var(--wot-coolgrey-8, var(--wot-filled-content));
   border-color: var(--wot-border-main, #2C2C2E);
   box-shadow: none;
+}
+
+.forget-hint {
+  display: block;
+  margin-bottom: 20rpx;
+  font-size: var(--font-sm, 24rpx);
+  line-height: 1.5;
 }
 
 .forget-footer {

--- a/frontend/web/src/api/module_system/user.ts
+++ b/frontend/web/src/api/module_system/user.ts
@@ -141,8 +141,6 @@ export default UserAPI;
 
 export interface ForgetPasswordForm {
   username: string;
-  new_password: string;
-  confirmPassword: string;
 }
 
 export interface RegisterForm {

--- a/frontend/web/src/locales/langs/en.json
+++ b/frontend/web/src/locales/langs/en.json
@@ -461,7 +461,9 @@
   },
   "forgetPassword": {
     "title": "Forgot password?",
-    "subTitle": "Enter your username and set a new password",
+    "subTitle": "Enter your username. An administrator will reset the password.",
+    "hint": "Passwords cannot be changed with only a username. After submitting, ask an administrator to reset it.",
+    "submitted": "If the account exists, please contact an administrator to reset the password",
     "placeholder": "Please enter your email",
     "submitBtnText": "Submit",
     "backBtnText": "Back"

--- a/frontend/web/src/locales/langs/zh.json
+++ b/frontend/web/src/locales/langs/zh.json
@@ -461,7 +461,9 @@
   },
   "forgetPassword": {
     "title": "忘记密码？",
-    "subTitle": "请输入账号并设置新密码",
+    "subTitle": "请输入账号，由管理员重置密码",
+    "hint": "系统不会根据用户名直接改密。提交后请联系管理员在后台重置。",
+    "submitted": "如果该账号存在，请联系管理员重置密码",
     "placeholder": "请输入您的电子邮件",
     "submitBtnText": "提交",
     "backBtnText": "返回"

--- a/frontend/web/src/views/module_system/auth/login/components/panels/FaLoginForgetPanel.vue
+++ b/frontend/web/src/views/module_system/auth/login/components/panels/FaLoginForgetPanel.vue
@@ -22,42 +22,9 @@
           </template>
         </ElInput>
       </ElFormItem>
-      <ElTooltip :visible="isCapsLock" :content="$t('login.capsLock')" placement="right">
-        <ElFormItem prop="new_password">
-          <ElInput
-            v-model.trim="forgetForm.new_password"
-            class="custom-height"
-            type="password"
-            autocomplete="off"
-            show-password
-            clearable
-            :placeholder="$t('login.placeholder.password')"
-            @keyup="checkCapsLock"
-          >
-            <template #prefix>
-              <ElIcon><Lock /></ElIcon>
-            </template>
-          </ElInput>
-        </ElFormItem>
-      </ElTooltip>
-      <ElTooltip :visible="isCapsLock" :content="$t('login.capsLock')" placement="right">
-        <ElFormItem prop="confirmPassword">
-          <ElInput
-            v-model.trim="forgetForm.confirmPassword"
-            class="custom-height"
-            type="password"
-            autocomplete="off"
-            show-password
-            clearable
-            :placeholder="$t('login.message.password.confirm')"
-            @keyup="checkCapsLock"
-          >
-            <template #prefix>
-              <ElIcon><Lock /></ElIcon>
-            </template>
-          </ElInput>
-        </ElFormItem>
-      </ElTooltip>
+      <p class="mb-2 text-xs text-(--el-text-color-secondary)">
+        {{ $t("forgetPassword.hint") }}
+      </p>
       <div class="mt-6">
         <ElButton
           class="h-11 w-full min-w-0 rounded-lg! text-base font-medium"
@@ -80,7 +47,7 @@
 </template>
 
 <script setup lang="ts">
-import { Lock, User } from "@element-plus/icons-vue";
+import { User } from "@element-plus/icons-vue";
 import type { ForgetPasswordForm } from "@/api/module_system/user";
 import type { FormRules } from "element-plus";
 
@@ -101,19 +68,9 @@ interface Emits {
   toLogin: [];
 }
 
-const emit = defineEmits<Emits>();
+defineEmits<Emits>();
 
 const formRef = ref();
-const isCapsLock = ref(false);
-
-function checkCapsLock(event: KeyboardEvent) {
-  if (event instanceof KeyboardEvent) {
-    isCapsLock.value = event.getModifierState("CapsLock");
-    if (event.key === "Enter") {
-      emit("submit");
-    }
-  }
-}
 
 defineExpose({
   validate: () => formRef.value?.validate?.(),

--- a/frontend/web/src/views/module_system/auth/login/index.vue
+++ b/frontend/web/src/views/module_system/auth/login/index.vue
@@ -381,8 +381,6 @@ const registerForm = reactive<RegisterForm>({
 
 const forgetForm = reactive<ForgetPasswordForm>({
   username: "",
-  new_password: "",
-  confirmPassword: "",
 });
 
 const validateRegisterPassword = (_rule: unknown, value: string, callback: (e?: Error) => void) => {
@@ -422,29 +420,8 @@ const registerRules = computed<FormRules<RegisterForm>>(() => ({
   ],
 }));
 
-const validateForgetConfirm = (_rule: unknown, value: string, callback: (e?: Error) => void) => {
-  if (!value) {
-    callback(new Error(t("login.message.password.required")));
-    return;
-  }
-  if (value !== forgetForm.new_password) {
-    callback(new Error(t("login.message.password.inconformity")));
-    return;
-  }
-  callback();
-};
-
 const forgetRules = computed<FormRules<ForgetPasswordForm>>(() => ({
   username: [{ required: true, message: t("login.message.username.required"), trigger: "blur" }],
-  new_password: [
-    { required: true, message: t("login.message.password.required"), trigger: "blur" },
-    { min: 6, message: t("login.message.password.min"), trigger: "blur" },
-  ],
-  confirmPassword: [
-    { required: true, message: t("login.message.password.required"), trigger: "blur" },
-    { min: 6, message: t("login.message.password.min"), trigger: "blur" },
-    { validator: validateForgetConfirm, trigger: "blur" },
-  ],
 }));
 
 const loginForm = reactive<LoginFormData>({
@@ -671,11 +648,9 @@ async function submitForget() {
     await forgetPanelRef.value.validate?.();
     forgetLoading.value = true;
     await UserAPI.forgetPassword(forgetForm);
+    ElMessage.success(t("forgetPassword.submitted"));
     loginForm.username = forgetForm.username;
-    loginForm.password = forgetForm.new_password;
     forgetForm.username = "";
-    forgetForm.new_password = "";
-    forgetForm.confirmPassword = "";
     setAuthPanel("login");
   } catch (error) {
     console.error("[Login] forget password:", error);


### PR DESCRIPTION
## Summary
- The public `POST /system/user/password/forget` endpoint accepted a username and new password with no login, email, SMS, or reset token, so any non-superuser account could be reset by anyone who knew the username.
- The endpoint now ignores a new password, does not change credentials, returns a generic message, and no longer leaks user details. Administrators continue to reset passwords via the existing authenticated `PUT /system/user/password/reset/{id}` API.
- Web and mini-program forget-password forms were updated to collect only a username and ask the user to contact an administrator.

## Test plan
- [ ] `POST /system/user/password/forget` with only `username` returns a generic success message and does not change the password
- [ ] The same request with a leftover `new_password` field still does not change the password
- [ ] Existing and missing usernames receive the same response
- [ ] `PUT /system/user/password/reset/{id}` still works for an authenticated admin
- [ ] Login page and mini-program forget-password UI no longer show new-password fields