### PR TITLE
fix(core): 修复子类 __table_args__ 覆盖导致通用索引丢失

### DIFF
--- a/backend/app/core/base_model.py
+++ b/backend/app/core/base_model.py
@@ -1,4 +1,5 @@
 from datetime import UTC, datetime
+from typing import Any
 
 from sqlalchemy import Boolean, DateTime, ForeignKey, Index, Integer, String
 from sqlalchemy.ext.asyncio import AsyncAttrs
@@ -7,7 +8,67 @@ from sqlalchemy.orm import DeclarativeBase, Mapped, declared_attr, mapped_column
 from app.utils.common_util import uuid4_str
 
 
-class MappedBase(AsyncAttrs, DeclarativeBase):
+def _merge_base_indexes(args: Any, table_name: str, *, has_status: bool) -> Any:
+    """把 ``ModelMixin`` 的通用软删除索引合并进子类声明的 ``__table_args__``。
+
+    ``status`` 列由各模型自行声明（**不在 ``ModelMixin`` 中**），因此只对确实有该列的表
+    补 ``ix_{表}_status_deleted``；``created_time`` / ``is_deleted`` 由 ``ModelMixin`` 提供，恒可补。
+
+    Args:
+        args: 子类声明的 ``__table_args__``（dict 或 tuple）。
+        table_name: 表名，用于生成索引名。
+        has_status: 该模型是否声明了 ``status`` 列。
+
+    Returns:
+        合并后的 ``__table_args__``（dict/tuple 形态与入参一致）。
+    """
+    indexes: tuple[Index, ...] = (Index(f"ix_{table_name}_created_deleted", "created_time", "is_deleted"),)
+    if has_status:
+        indexes = (Index(f"ix_{table_name}_status_deleted", "status", "is_deleted"), *indexes)
+
+    if isinstance(args, dict):
+        # 字典形式（如 {"comment": "..."}）：索引在前、字典结尾（SQLAlchemy 约定）
+        return (*indexes, args)
+    if isinstance(args, tuple):
+        # 元组形式：按索引名去重，避免与子类自定义索引重名导致重复创建
+        existing = {idx.name for idx in args if isinstance(idx, Index)}
+        missing = tuple(idx for idx in indexes if idx.name not in existing)
+        return (*missing, *args)
+    return args
+
+
+class _DeclarativeMeta(type(DeclarativeBase)):
+    """在 declarative 扫描**之前**合并通用索引。
+
+    为何必须用元类而不是 ``__init_subclass__``：SQLAlchemy 的 declarative 读取的是
+    传给元类的 ``namespace`` 字典来构建 Table；而 ``__init_subclass__`` 在
+    ``type.__new__`` 末尾才触发，此时表结构已按原值构建完毕——实测在
+    ``__init_subclass__`` 里改写 ``cls.__table_args__`` 无效（``__dict__`` 已是新值，
+    但 ``__table__.indexes`` 里没有索引）。
+
+    同理，``declared_attr.directive`` 也无法自行合并：子类一旦声明了自己的
+    ``__table_args__``，mixin 的 directive 根本不会被调用。
+    """
+
+    def __new__(mcls, name: str, bases: tuple[type, ...], namespace: dict[str, Any], **kwargs: Any) -> type:
+        args = namespace.get("__table_args__")
+        if args is None:
+            return super().__new__(mcls, name, bases, namespace, **kwargs)
+        # 未显式声明 __tablename__ 时，与 MappedBase 的默认规则保持一致（类名小写）
+        table_name = namespace.get("__tablename__") or name.lower()
+        # 只处理继承 ModelMixin 的模型：纯关联表（仅继承 MappedBase）没有
+        # created_time / is_deleted 列，补索引会因列不存在而建表失败。
+        has_soft_delete = "created_time" in namespace or any("created_time" in getattr(b, "__dict__", {}) for b in bases)
+        # status 列由各模型自行声明（Mixin 中没有），据此决定是否补 status 索引，
+        # 避免给无该列的表（如 ChatGroupModel）建出引用不存在列的索引。
+        has_status = "status" in namespace or any("status" in getattr(b, "__dict__", {}) for b in bases)
+        skip = namespace.get("__table_args_skip_base_index__")
+        if table_name and has_soft_delete and not skip:
+            namespace["__table_args__"] = _merge_base_indexes(args, table_name, has_status=has_status)
+        return super().__new__(mcls, name, bases, namespace, **kwargs)
+
+
+class MappedBase(AsyncAttrs, DeclarativeBase, metaclass=_DeclarativeMeta):
     """声明式基类
 
     `AsyncAttrs <https://docs.sqlalchemy.org/en/20/orm/extensions/asyncio.html#sqlalchemy.ext.asyncio.AsyncAttrs>`__

--- a/backend/tests/test_base_model_indexes.py
+++ b/backend/tests/test_base_model_indexes.py
@@ -1,0 +1,85 @@
+"""模型通用软删除索引回归测试。
+
+背景：子类一旦显式声明 ``__table_args__``，会**整体覆盖** ``ModelMixin`` 的
+``declared_attr.directive``（SQLAlchemy 不做自动合并），导致
+``ix_{表}_status_deleted`` / ``ix_{表}_created_deleted`` 两个索引丢失——
+而软删除查询全都带 ``is_deleted`` 条件。
+
+``core/base_model.py`` 的 ``_DeclarativeMeta`` 会在 declarative 扫描之前合并补全这两个索引。
+本测试用于验证合并逻辑对所有模型生效，并防止后续新增模型时再次退化。
+
+注意：``status`` 列由各模型自行声明（不在 ``ModelMixin`` 中），因此只有确实存在该列的表
+才应带 ``ix_{表}_status_deleted``；``created_time`` / ``is_deleted`` 由 Mixin 提供，每张表都应有。
+"""
+
+import importlib
+import pkgutil
+
+import pytest
+
+import app.api.v1
+from app.core.base_model import MappedBase, ModelMixin
+
+
+def _import_all_models() -> None:
+    """导入 api/v1 下所有 model 模块，使 ORM 映射全部注册。"""
+    for mod in pkgutil.walk_packages(app.api.v1.__path__, prefix="app.api.v1."):
+        if mod.name.endswith(".model"):
+            importlib.import_module(mod.name)
+
+
+def _iter_model_mixin_tables():
+    """产出所有继承 ModelMixin 的具体模型与其主表。"""
+    for mapper in MappedBase.registry.mappers:
+        cls = mapper.class_
+        if issubclass(cls, ModelMixin) and not cls.__dict__.get("__abstract__"):
+            yield cls, mapper.local_table
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _load_models():
+    """本模块用例执行前先导入全部模型。"""
+    _import_all_models()
+
+
+def test_models_are_imported():
+    """导入逻辑本身要有效，否则后面的断言会"空跑通过"。"""
+    tables = list(_iter_model_mixin_tables())
+    assert tables, "未发现任何 ModelMixin 模型，模型导入逻辑可能失效"
+
+
+def test_soft_delete_indexes_exist():
+    """每张继承 ModelMixin 的表都应具备与其列匹配的软删除索引。"""
+    missing: list[str] = []
+    for cls, table in _iter_model_mixin_tables():
+        if cls.__dict__.get("__table_args_skip_base_index__"):
+            continue
+        index_names = {idx.name for idx in table.indexes}
+        expected = [f"ix_{table.name}_created_deleted"]
+        if "status" in table.columns:
+            expected.append(f"ix_{table.name}_status_deleted")
+        for want in expected:
+            if want not in index_names:
+                missing.append(f"{cls.__name__}({table.name}) 缺少 {want}")
+
+    assert not missing, "以下模型缺少通用软删除索引:\n" + "\n".join(missing)
+
+
+def test_no_index_on_missing_column():
+    """不得给没有 status 列的表建 status 索引，否则建表时会因列不存在而失败。"""
+    invalid: list[str] = []
+    for cls, table in _iter_model_mixin_tables():
+        index_names = {idx.name for idx in table.indexes}
+        want = f"ix_{table.name}_status_deleted"
+        if want in index_names and "status" not in table.columns:
+            invalid.append(f"{cls.__name__}({table.name}) 无 status 列却建了 {want}")
+
+    assert not invalid, "以下模型索引引用了不存在的列:\n" + "\n".join(invalid)
+
+
+def test_no_duplicate_index_names():
+    """合并逻辑不得与子类自定义索引重名，否则建表时会重复创建。"""
+    for cls, table in _iter_model_mixin_tables():
+        names = [idx.name for idx in table.indexes]
+        duplicated = {name for name in names if names.count(name) > 1}
+        assert not duplicated, f"{cls.__name__}({table.name}) 存在重复索引名: {duplicated}"


### PR DESCRIPTION
## 问题

`ModelMixin` 通过 `declared_attr.directive` 为所有继承它的表声明了两个通用软删除索引：

- `ix_{表}_status_deleted` (status, is_deleted)
- `ix_{表}_created_deleted` (created_time, is_deleted)

但在 SQLAlchemy 中，**子类一旦显式声明 `__table_args__`，就会整体覆盖该 directive，且不会与父类自动合并**，导致这两个索引全部丢失。

实测影响：仓库中 32 个模型全部声明了 `__table_args__`，因此修复前**没有任何一张表**带这两个索引 —— 28 张 `ModelMixin` 表共缺失 **52 个索引**。而软删除查询（`CRUDBase` 的 `_build_conditions`）全都带 `is_deleted` 条件，索引缺失对这类查询影响直接。

## 修复

在 `core/base_model.py` 中新增 `_DeclarativeMeta`（继承 `type(DeclarativeBase)`），在 declarative 扫描**之前**把通用索引合并进子类声明的 `__table_args__`：

- 支持 `dict`（如 `{"comment": "..."}`）与 `tuple` 两种声明形态
- `tuple` 形态按索引名去重，避免与子类自定义索引重名导致重复创建
- 只处理**有 `created_time` / `is_deleted` 列**的表，纯关联表（如 `sys_role_menus`）不补，否则会因列不存在而建表失败
- `status` 列由各模型自行声明（不在 Mixin 中），按列存在性决定是否补 `status` 索引
- 提供逃生舱：模型声明 `__table_args_skip_base_index__ = True` 可跳过（适用于写放大敏感的大表）

**为什么不用 `__init_subclass__`**：SQLAlchemy 的 declarative 读取的是传给元类的 `namespace` 字典来构建 Table，而 `__init_subclass__` 在 `type.__new__` 末尾才触发 —— 实测此时改写 `cls.__table_args__` 无效（`__dict__` 已是新值，但 `__table__.indexes` 里没有索引）。同理 `declared_attr.directive` 也无法自行合并：子类声明了自己的 `__table_args__` 后，Mixin 的 directive 根本不会被调用。

## 测试

新增 `backend/tests/test_base_model_indexes.py`，4 项用例：

- 模型导入有效性（防止断言"空跑通过"）
- 每张 `ModelMixin` 表的软删除索引存在
- 不得给不存在的列建索引
- 不得出现重复索引名

验证结果：

```
tests/test_base_model_indexes.py   4 passed
tests/test_main.py                 2 passed
ruff check                         All checks passed
```

## 影响范围

- 仅新增索引，不改动任何既有表结构或数据
- 对已存在的数据库，需另行执行迁移补建索引（代码只影响此后新建的表），本 PR 不包含该迁移
