### PR TITLE
fix(form): restore FaForm label suffix

### DIFF
--- a/frontend/web/src/components/forms/fa-form/index.vue
+++ b/frontend/web/src/components/forms/fa-form/index.vue
@@ -22,11 +22,12 @@
           >
             <ElFormItem
               :prop="item.key"
+              :label="typeof item.label === 'string' ? item.label : ''"
               :label-width="item.label ? item.labelWidth || labelWidth : undefined"
             >
-              <template #label v-if="item.label">
-                <component v-if="typeof item.label !== 'string'" :is="item.label" />
-                <span v-else>{{ item.label }}</span>
+              <template v-if="item.label && typeof item.label !== 'string'" #label="{ label }">
+                <component :is="item.label" />
+                <span>{{ label }}</span>
               </template>
               <slot :name="item.key" :item="item" :modelValue="modelValue">
                 <component
@@ -119,11 +120,12 @@
         >
           <ElFormItem
             :prop="item.key"
+            :label="typeof item.label === 'string' ? item.label : ''"
             :label-width="item.label ? item.labelWidth || labelWidth : undefined"
           >
-            <template #label v-if="item.label">
-              <component v-if="typeof item.label !== 'string'" :is="item.label" />
-              <span v-else>{{ item.label }}</span>
+            <template v-if="item.label && typeof item.label !== 'string'" #label="{ label }">
+              <component :is="item.label" />
+              <span>{{ label }}</span>
             </template>
             <slot :name="item.key" :item="item" :modelValue="modelValue">
               <component


### PR DESCRIPTION
## 修复内容

修复 `FaForm` 传入 `label-suffix` 后不生效的问题。

- 字符串类型的 `label` 改为使用 `ElFormItem` 默认标签渲染，使 `label-suffix` 正常生效。
- 保留自定义组件标签的插槽支持，并渲染 Element Plus 提供的后缀。
- 同步修复带滚动条和不带滚动条两条渲染分支。